### PR TITLE
[SIGN-1, SIGN-2] 회원가입/로그인 화면 구현 및 api 연결

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+.env

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@radix-ui/react-slot": "^1.1.0",
     "@radix-ui/react-switch": "^1.1.1",
     "@types/react-router-dom": "^5.3.3",
+    "axios": "^1.7.9",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.468.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       '@types/react-router-dom':
         specifier: ^5.3.3
         version: 5.3.3
+      axios:
+        specifier: ^1.7.9
+        version: 1.7.9
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -1013,12 +1016,18 @@ packages:
     resolution: {integrity: sha512-y+CcFFwelSXpLZk/7fMB2mUbGtX9lKycf1MWJ7CaTIERyitVlyQx6C+sxcROU2BAJ24OiZyK+8wj2i8AlBoS3A==}
     engines: {node: '>=10'}
 
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
   autoprefixer@10.4.20:
     resolution: {integrity: sha512-XY25y5xSv/wEoqzDyXXME4AFfkZI0P23z6Fs3YgymDnKJkCGOnkL0iTxCa85UTqaSgfcqyf3UA6+c7wUvx/16g==}
     engines: {node: ^10 || ^12 || >=14}
     hasBin: true
     peerDependencies:
       postcss: ^8.1.0
+
+  axios@1.7.9:
+    resolution: {integrity: sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==}
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -1075,6 +1084,10 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
     engines: {node: '>= 6'}
@@ -1108,6 +1121,10 @@ packages:
 
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
 
   detect-node-es@1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
@@ -1231,9 +1248,22 @@ packages:
   flatted@3.3.2:
     resolution: {integrity: sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA==}
 
+  follow-redirects@1.15.9:
+    resolution: {integrity: sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
   foreground-child@3.3.0:
     resolution: {integrity: sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==}
     engines: {node: '>=14'}
+
+  form-data@4.0.1:
+    resolution: {integrity: sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==}
+    engines: {node: '>= 6'}
 
   fraction.js@4.3.7:
     resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
@@ -1417,6 +1447,14 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
 
@@ -1560,6 +1598,9 @@ packages:
 
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
+
+  proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -2723,6 +2764,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  asynckit@0.4.0: {}
+
   autoprefixer@10.4.20(postcss@8.4.49):
     dependencies:
       browserslist: 4.24.2
@@ -2732,6 +2775,14 @@ snapshots:
       picocolors: 1.1.1
       postcss: 8.4.49
       postcss-value-parser: 4.2.0
+
+  axios@1.7.9:
+    dependencies:
+      follow-redirects: 1.15.9
+      form-data: 4.0.1
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
 
   balanced-match@1.0.2: {}
 
@@ -2792,6 +2843,10 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
   commander@4.1.1: {}
 
   concat-map@0.0.1: {}
@@ -2813,6 +2868,8 @@ snapshots:
       ms: 2.1.3
 
   deep-is@0.1.4: {}
+
+  delayed-stream@1.0.0: {}
 
   detect-node-es@1.1.0: {}
 
@@ -2973,10 +3030,18 @@ snapshots:
 
   flatted@3.3.2: {}
 
+  follow-redirects@1.15.9: {}
+
   foreground-child@3.3.0:
     dependencies:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
+
+  form-data@4.0.1:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      mime-types: 2.1.35
 
   fraction.js@4.3.7: {}
 
@@ -3132,6 +3197,12 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.1
 
+  mime-db@1.52.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
+
   minimatch@3.1.2:
     dependencies:
       brace-expansion: 1.1.11
@@ -3254,6 +3325,8 @@ snapshots:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
+
+  proxy-from-env@1.1.0: {}
 
   punycode@2.3.1: {}
 

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,0 +1,17 @@
+import axios, { AxiosInstance } from "axios";
+
+const BASE_URL: string = import.meta.env.VITE_API_HOST;
+const VERSION = import.meta.env.VITE_API_VERSION;
+
+const HEADERS: Record<string, string | boolean> = {
+  "Access-Control-Allow-Origin": "*",
+  "Content-Type": "application/json; charset=utf-8",
+  withCredentials: true,
+};
+
+const createAxios = (): AxiosInstance => {
+  return axios.create({ baseURL: BASE_URL + VERSION, headers: HEADERS });
+};
+
+// No token
+export const api: AxiosInstance = createAxios();

--- a/src/api/member/index.ts
+++ b/src/api/member/index.ts
@@ -1,0 +1,20 @@
+import { AxiosResponse } from "axios";
+import { api } from "..";
+import * as T from "./type";
+
+export const member = {
+  join: async (
+    param: T.MemberJoinParam
+  ): Promise<AxiosResponse<T.MemberJoinResponse>> => {
+    const res = await api.post("/member", param);
+
+    return res;
+  },
+  login: async (
+    param: T.MemberLoginParam
+  ): Promise<AxiosResponse<T.MemberLoginResponse>> => {
+    const res = await api.post("/auth/login", param);
+
+    return res;
+  },
+};

--- a/src/api/member/type.ts
+++ b/src/api/member/type.ts
@@ -1,0 +1,23 @@
+export type MemberJoinParam = {
+  nickname: string;
+  password: string;
+  email: `${string}@${string}`;
+};
+
+export type MemberJoinResponse = {
+  status: string;
+  message: string;
+};
+
+export type MemberLoginParam = {
+  nickname: string;
+  password: string | number;
+};
+
+export type MemberLoginResponse = {
+  status: string;
+  message: string;
+  data: {
+    id: number;
+  };
+};

--- a/src/api/member/type.ts
+++ b/src/api/member/type.ts
@@ -5,7 +5,7 @@ export type MemberJoinParam = {
 };
 
 export type MemberJoinResponse = {
-  status: string;
+  status: "OK" | "BAD_REQUEST";
   message: string;
 };
 
@@ -15,7 +15,7 @@ export type MemberLoginParam = {
 };
 
 export type MemberLoginResponse = {
-  status: string;
+  status: "OK" | "BAD_REQUEST";
   message: string;
   data: {
     id: number;

--- a/src/pages/_mock/index.tsx
+++ b/src/pages/_mock/index.tsx
@@ -12,6 +12,12 @@ type MockRouteType = {
 
 export function MockRouteList() {
   const MockRouteList: MockRouteType[] = [
+    // 멤버
+    {
+      task: "SIGN-1",
+      path: "/member-join",
+      component: "MemberJoin",
+    },
     // 질문 생성
     {
       task: "QCRT-1",

--- a/src/pages/_mock/index.tsx
+++ b/src/pages/_mock/index.tsx
@@ -18,6 +18,11 @@ export function MockRouteList() {
       path: "/member-join",
       component: "MemberJoin",
     },
+    {
+      task: "SIGN-2",
+      path: "/member-login",
+      component: "MemberLogin",
+    },
     // 질문 생성
     {
       task: "QCRT-1",

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -5,6 +5,7 @@ import { MockRouteList } from "./_mock";
 import Main from "./main";
 
 import MemberJoin from "./member-join";
+import MemberLogin from "./member-login";
 
 import QuestionCreate from "./question-create";
 import QuestionCreateDetail from "./question-create-detail";
@@ -21,8 +22,12 @@ export default function Routing() {
         <Switch>
           {/* Route 확인용 (작업 시 꼭 추가 부탁드립니다!!) */}
           <Route exact path="/" render={() => <MockRouteList />} />
+
           <Route exact path="/main" render={() => <Main />} />
+
           <Route exact path="/member-join" render={() => <MemberJoin />} />
+          <Route exact path="/member-login" render={() => <MemberLogin />} />
+
           <Route
             exact
             path="/question-create"
@@ -38,13 +43,16 @@ export default function Routing() {
             path="/question-create-complete"
             render={() => <QuestionCreateComplete />}
           />
-          <Route exact path="/answer-create" render={() => <AnswerCreate />} />
+
           <Route
             exact
             path="/self-reflection"
             render={() => <SelfReflection />}
           />
+
+          <Route exact path="/answer-create" render={() => <AnswerCreate />} />
           <Route exact path="/answer-result" render={() => <AnswerResult />} />
+
           <Redirect to="/" />
         </Switch>
       </BrowserRouter>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,12 +1,18 @@
 import { Route, Switch, Redirect, BrowserRouter } from "react-router-dom";
-import QuestionCreateDetail from "./question-create-detail";
-import Main from "./main";
+
 import { MockRouteList } from "./_mock";
-import QuestionCreateComplete from "./question-create-complete";
+
+import Main from "./main";
+
+import MemberJoin from "./member-join";
+
 import QuestionCreate from "./question-create";
+import QuestionCreateDetail from "./question-create-detail";
+import QuestionCreateComplete from "./question-create-complete";
+
 import AnswerCreate from "./answer-create";
-import SelfReflection from "@/pages/self-reflection";
 import AnswerResult from "./answer-result";
+import SelfReflection from "./self-reflection";
 
 export default function Routing() {
   return (
@@ -16,6 +22,7 @@ export default function Routing() {
           {/* Route 확인용 (작업 시 꼭 추가 부탁드립니다!!) */}
           <Route exact path="/" render={() => <MockRouteList />} />
           <Route exact path="/main" render={() => <Main />} />
+          <Route exact path="/member-join" render={() => <MemberJoin />} />
           <Route
             exact
             path="/question-create"

--- a/src/pages/main/components/NonLoggedSection.tsx
+++ b/src/pages/main/components/NonLoggedSection.tsx
@@ -1,0 +1,34 @@
+import { useHistory } from "react-router-dom";
+
+import { Button } from "@/components/ui/button";
+
+export default function NonLoggedSection() {
+  const history = useHistory();
+
+  function goToLoginPage() {
+    history.push("/member-login");
+  }
+  return (
+    <div className="flex flex-col items-center gap-3">
+      <div className="text-center pt-20 pb-5 mb-3">
+        <h2 className="text-h2 text-primary">부꾸러미</h2>
+
+        <div className="text-base font-bold mt-3">
+          <p>키워드를 통해 올 한해를 돌아보세요!</p>
+          <p>나는 과연 올해 어떤 사람이었나요?</p>
+        </div>
+      </div>
+
+      <div className="mb-10">
+        {/** 구역을 잡기위한 임시 영역입니다. 삭제 예정 */}
+        <div className="w-36 h-36 border-2">image</div>
+      </div>
+
+      <div className="flex flex-col items-center">
+        <Button onClick={goToLoginPage} className="w-[50vw]">
+          이메일로 계속하기
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/main/index.tsx
+++ b/src/pages/main/index.tsx
@@ -10,14 +10,13 @@ import NonLoggedSection from "./components/NonLoggedSection";
 import { MOCK_MEMBER } from "../_mock/data/member";
 
 export default function Main() {
-  const [hasUserId, setHasUserIdValue] = useState<boolean | null>(null);
+  const [hasUserId, setHasUserId] = useState<boolean>(false);
 
   useEffect(() => {
     const checkLocalStorage = () => {
       const userId = localStorage.getItem("userId");
-      console.log(userId);
 
-      setHasUserIdValue(userId !== null);
+      setHasUserId(userId !== null);
     };
 
     checkLocalStorage();

--- a/src/pages/main/index.tsx
+++ b/src/pages/main/index.tsx
@@ -1,10 +1,28 @@
+import { useState, useEffect } from "react";
+
 import { getRandomIndex } from "@/lib/utils";
 import { Answer } from "@/types/answer";
+
 import WithoutAnswer from "./components/WithoutAnswer";
 import WithAnswer from "./components/WithAnswer";
+import NonLoggedSection from "./components/NonLoggedSection";
+
 import { MOCK_MEMBER } from "../_mock/data/member";
 
 export default function Main() {
+  const [hasUserId, setHasUserIdValue] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    const checkLocalStorage = () => {
+      const userId = localStorage.getItem("userId");
+      console.log(userId);
+
+      setHasUserIdValue(userId !== null);
+    };
+
+    checkLocalStorage();
+  }, []);
+
   const answers: Answer[] = [
     {
       sender: "someone",
@@ -24,15 +42,24 @@ export default function Main() {
   const previewMessage = answers[getRandomIndex(answers)];
 
   return (
-    <section className="flex flex-col justify-center items-center h-screen">
-      <h2 className="font-bold text-2xl mb-2">
-        {MOCK_MEMBER.nickname}님의 보따리
-      </h2>
-      {answerCount < 1 ? (
-        <WithoutAnswer />
+    <>
+      {!hasUserId ? (
+        <NonLoggedSection />
       ) : (
-        <WithAnswer answerCount={answerCount} previewMessage={previewMessage} />
+        <section className="flex flex-col justify-center items-center h-screen">
+          <h2 className="font-bold text-2xl mb-2">
+            {MOCK_MEMBER.nickname}님의 보따리
+          </h2>
+          {answerCount < 1 ? (
+            <WithoutAnswer />
+          ) : (
+            <WithAnswer
+              answerCount={answerCount}
+              previewMessage={previewMessage}
+            />
+          )}
+        </section>
       )}
-    </section>
+    </>
   );
 }

--- a/src/pages/member-join/index.tsx
+++ b/src/pages/member-join/index.tsx
@@ -1,0 +1,106 @@
+import { z } from "zod";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+
+import { member } from "@/api/member";
+import { MemberJoinParam } from "@/api/member/type";
+import { memberJoin, MemberJoinFormType } from "./schema/memberJoinSchema";
+
+import { Button } from "@/components/ui/button";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+
+export default function MemberJoin() {
+  const form = useForm<MemberJoinFormType>({
+    resolver: zodResolver(memberJoin),
+    defaultValues: {
+      nickname: "",
+      email: "",
+      password: "",
+    },
+  });
+
+  function onSubmit(values: z.infer<typeof memberJoin>) {
+    const joinParams: MemberJoinParam = {
+      ...values,
+      email: values.email as `${string}@${string}`,
+    };
+    member.join(joinParams).then((res) => {
+      const data = res.data;
+
+      if (data.status === "OK") {
+        console.log("Go To Login Page");
+      }
+    });
+  }
+
+  return (
+    <>
+      <div className="text-center pt-20 pb-10 mb-3">
+        <h3 className="text-h3">
+          내 스스로 난 <span className="text-primary">어떤 사람</span>이었는지
+        </h3>
+        <h3 className="text-h3">정의할 수 있는 닉네임을 만들어 보아요!</h3>
+      </div>
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
+          <FormField
+            control={form.control}
+            name="nickname"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>닉네임</FormLabel>
+                <FormControl>
+                  <Input placeholder="닉네임을 입력하세요" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="email"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>이메일</FormLabel>
+                <FormControl>
+                  <Input
+                    type="email"
+                    placeholder="이메일을 입력하세요"
+                    {...field}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="password"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>비밀번호</FormLabel>
+                <FormControl>
+                  <Input
+                    type="password"
+                    placeholder="비밀번호를 입력하세요"
+                    {...field}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <Button type="submit">회원가입</Button>
+        </form>
+      </Form>
+    </>
+  );
+}

--- a/src/pages/member-join/schema/memberJoinSchema.ts
+++ b/src/pages/member-join/schema/memberJoinSchema.ts
@@ -1,0 +1,11 @@
+import { z } from "zod";
+
+export const memberJoin = z.object({
+  nickname: z.string().max(5, { message: "닉네임은 최대 5자 입니다." }),
+  email: z.string().email({ message: "올바른 이메일 형식이 아닙니다." }),
+  password: z.string().regex(/^\d{4,}$/, {
+    message: "비밀번호는 4자리 이상의 숫자로만 구성되어야 합니다.",
+  }),
+});
+
+export type MemberJoinFormType = z.infer<typeof memberJoin>;

--- a/src/pages/member-login/index.tsx
+++ b/src/pages/member-login/index.tsx
@@ -35,7 +35,8 @@ export default function MemberJoin() {
 
       setLoginResponse(data);
       if (data.status === "OK") {
-        console.log("Go To Main Page");
+        history.push("/main");
+        localStorage.setItem("userId", String(data.data.id));
       }
     });
   }

--- a/src/pages/member-login/index.tsx
+++ b/src/pages/member-login/index.tsx
@@ -1,11 +1,8 @@
-import { useForm } from "react-hook-form";
 import { useHistory } from "react-router-dom";
-import { z } from "zod";
-import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
 
 import { member } from "@/api/member";
-import { MemberJoinParam } from "@/api/member/type";
-import { memberJoin, MemberJoinFormType } from "./schema/memberJoinSchema";
+import { MemberLoginParam, MemberLoginResponse } from "@/api/member/type";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -15,44 +12,43 @@ import {
   FormItem,
   FormLabel,
   FormMessage,
+  FormDescription,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
+import { useState } from "react";
 
 export default function MemberJoin() {
+  const [loginResponse, setLoginResponse] = useState<MemberLoginResponse>();
+
   const history = useHistory();
 
-  const form = useForm<MemberJoinFormType>({
-    resolver: zodResolver(memberJoin),
+  const form = useForm<MemberLoginParam>({
     defaultValues: {
       nickname: "",
-      email: "",
       password: "",
     },
   });
 
-  function onSubmit(values: z.infer<typeof memberJoin>) {
-    const joinParams: MemberJoinParam = {
-      ...values,
-      email: values.email as `${string}@${string}`,
-    };
-    member.join(joinParams).then((res) => {
+  function onSubmit(values: MemberLoginParam) {
+    member.login(values).then((res) => {
       const data = res.data;
 
+      setLoginResponse(data);
       if (data.status === "OK") {
-        history.push("/member-login");
+        console.log("Go To Main Page");
       }
     });
+  }
+
+  function goToJoinPage() {
+    history.push("/member-join");
   }
 
   return (
     <>
       <div className="text-center pt-20 pb-10 mb-3">
-        <h3 className="text-h3">
-          내 스스로 난 <span className="text-primary">어떤 사람</span>이었는지
-        </h3>
-        <h3 className="text-h3">정의할 수 있는 닉네임을 만들어 보아요!</h3>
+        <h2 className="text-h2 text-primary">로그인</h2>
       </div>
-
       <Form {...form}>
         <form
           onSubmit={form.handleSubmit(onSubmit)}
@@ -73,23 +69,6 @@ export default function MemberJoin() {
           />
           <FormField
             control={form.control}
-            name="email"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>이메일</FormLabel>
-                <FormControl>
-                  <Input
-                    type="email"
-                    placeholder="이메일을 입력하세요"
-                    {...field}
-                  />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-          <FormField
-            control={form.control}
             name="password"
             render={({ field }) => (
               <FormItem>
@@ -101,13 +80,25 @@ export default function MemberJoin() {
                     {...field}
                   />
                 </FormControl>
+                {loginResponse?.status === "BAD_REQUEST" && (
+                  <FormDescription>{loginResponse.message}</FormDescription>
+                )}
                 <FormMessage />
               </FormItem>
             )}
           />
-          <Button type="submit">회원가입</Button>
+          <Button type="submit">로그인</Button>
         </form>
       </Form>
+
+      <Button
+        onClick={goToJoinPage}
+        type="submit"
+        variant="link"
+        className="mx-auto block mt-4"
+      >
+        일반 회원가입
+      </Button>
     </>
   );
 }

--- a/src/pages/member-login/index.tsx
+++ b/src/pages/member-login/index.tsx
@@ -2,7 +2,7 @@ import { useHistory } from "react-router-dom";
 import { useForm } from "react-hook-form";
 
 import { member } from "@/api/member";
-import { MemberLoginParam, MemberLoginResponse } from "@/api/member/type";
+import { MemberLoginParam } from "@/api/member/type";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -18,7 +18,7 @@ import { Input } from "@/components/ui/input";
 import { useState } from "react";
 
 export default function MemberJoin() {
-  const [loginResponse, setLoginResponse] = useState<MemberLoginResponse>();
+  const [errorMessage, setErrorMessage] = useState<string>();
 
   const history = useHistory();
 
@@ -33,10 +33,12 @@ export default function MemberJoin() {
     member.login(values).then((res) => {
       const data = res.data;
 
-      setLoginResponse(data);
       if (data.status === "OK") {
         history.push("/main");
         localStorage.setItem("userId", String(data.data.id));
+        setErrorMessage("");
+      } else {
+        setErrorMessage(data.message);
       }
     });
   }
@@ -81,8 +83,8 @@ export default function MemberJoin() {
                     {...field}
                   />
                 </FormControl>
-                {loginResponse?.status === "BAD_REQUEST" && (
-                  <FormDescription>{loginResponse.message}</FormDescription>
+                {errorMessage && (
+                  <FormDescription>{errorMessage}</FormDescription>
                 )}
                 <FormMessage />
               </FormItem>

--- a/vite-env.d.ts
+++ b/vite-env.d.ts
@@ -1,0 +1,10 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_API_HOST: string;
+  readonly VITE_API_VERSION: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
## 무엇을 위한 PR인가요?
- [x] 신규 기능 추가 :
- [ ] 버그 수정 :
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 :

## 변경사항 및 이유

![introduction](https://github.com/user-attachments/assets/5dd70a93-0179-4713-83de-3a52620e5cb4)

### PR 특이 사항

- 회원가입 및 로그인 화면 구현
- 비로그인시 메인페이지 구현
  - 로그인 여부는 임시로 로그인 성공후 들어오는 `userId`값을 localStorage에 저장하여 판단토록 하였습니다.
- 회원가입/로그인 API 연결
  - api instance setting 코드를 공통 사항으로 세팅해두었습니다.

> api 세팅과 관련해서 수정하거나 개선할 사항이 있다면 말씀해주세요.
> 더 좋은 방식이 있다면 전면 수정하여도 괜찮습니다! 
