### PR TITLE
[MAIN-7] 설정 페이지 화면 구현 및 api 연결

### DIFF
--- a/src/api/settings/index.ts
+++ b/src/api/settings/index.ts
@@ -1,0 +1,18 @@
+import { AxiosResponse } from "axios";
+import { MemberResponse, MemberSettings } from "@/types/member";
+import { api } from "@/api";
+
+export const userInfo = {
+  getSettings: async (
+    memberId: string
+  ): Promise<AxiosResponse<MemberResponse>> => {
+    return api.get(`/member/${memberId}`);
+  },
+
+  updateSettings: async (
+    memberId: string,
+    settings: MemberSettings
+  ): Promise<AxiosResponse<MemberResponse>> => {
+    return api.put(`/member/${memberId}`, settings);
+  },
+};

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -14,6 +14,7 @@ import QuestionCreateComplete from "./question-create-complete";
 import AnswerCreate from "./answer-create";
 import AnswerResult from "./answer-result";
 import SelfReflection from "./self-reflection";
+import Settings from "@/pages/settings";
 
 export default function Routing() {
   return (
@@ -52,6 +53,7 @@ export default function Routing() {
 
           <Route exact path="/answer-create" render={() => <AnswerCreate />} />
           <Route exact path="/answer-result" render={() => <AnswerResult />} />
+          <Route exact path="/settings" render={() => <Settings />} />
 
           <Redirect to="/" />
         </Switch>

--- a/src/pages/settings/index.tsx
+++ b/src/pages/settings/index.tsx
@@ -1,0 +1,92 @@
+import { useEffect, useState } from "react";
+import { Switch } from "@/components/ui/switch";
+import { Label } from "@/components/ui/label";
+import { MemberSettings } from "@/types/member";
+import { userInfo } from "@/api/settings";
+
+export default function Settings() {
+  const memberId = "9"; // 임시 memberId
+  const [settings, setSettings] = useState<MemberSettings>({
+    isPublicVisible: 0,
+    isCountVisible: 0,
+    isAuthRequired: 0,
+  });
+
+  const handleUpdateSetting = async (key: keyof MemberSettings) => {
+    const newSettings = {
+      ...settings,
+      [key]: settings[key] === 1 ? 0 : 1,
+    };
+
+    try {
+      await userInfo.updateSettings(memberId, newSettings);
+      setSettings(newSettings);
+    } catch (error) {
+      setSettings(settings);
+    }
+  };
+
+  const fetchSettings = async () => {
+    try {
+      const response = await userInfo.getSettings(memberId);
+      const { isPublicVisible, isCountVisible, isAuthRequired } =
+        response.data.data;
+      setSettings({ isPublicVisible, isCountVisible, isAuthRequired });
+    } catch (error) {
+      console.error("설정을 불러오는데 실패했습니다.");
+    }
+  };
+
+  useEffect(() => {
+    fetchSettings();
+  }, [memberId]);
+
+  return (
+    <div>
+      <h2 className="text-h2 text-gray-dark">설정</h2>
+      <div className="space-y-6">
+        <div className="flex flex-col gap-4">
+          <div className="flex items-center justify-between">
+            <Label
+              htmlFor="login-required"
+              className="text-h6 text-gray-dark flex-1"
+            >
+              회원만 대답을 넣을 수 있게 할까요?
+            </Label>
+            <Switch
+              id="login-required"
+              checked={settings.isPublicVisible === 1}
+              onCheckedChange={() => handleUpdateSetting("isPublicVisible")}
+            />
+          </div>
+          <div className="flex items-center justify-between">
+            <Label
+              htmlFor="pouch-visible"
+              className="text-h2 text-gray-dark flex-1"
+            >
+              다른 사람도 내 보따리를 열어볼 수 있게 할까요?
+            </Label>
+            <Switch
+              id="pouch-visible"
+              checked={settings.isCountVisible === 1}
+              onCheckedChange={() => handleUpdateSetting("isCountVisible")}
+            />
+          </div>
+          <div className="flex items-center justify-between">
+            <Label
+              htmlFor="marble-count"
+              className="text-h6 text-gray-dark flex-1"
+            >
+              내 보따리에 담긴 답변 갯수가 보이게 할까요?
+            </Label>
+            <Switch
+              id="marble-count"
+              checked={settings.isAuthRequired === 1}
+              onCheckedChange={() => handleUpdateSetting("isAuthRequired")}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/types/member.ts
+++ b/src/types/member.ts
@@ -1,3 +1,23 @@
 export interface Member {
   nickname: string;
 }
+
+export interface MemberSettings {
+  isPublicVisible: number;
+  isCountVisible: number;
+  isAuthRequired: number;
+}
+
+export interface MemberResponse {
+  status: string;
+  message: string;
+  data: {
+    id: string;
+    nickname: string;
+    email: string;
+    isPublicVisible: number;
+    isCountVisible: number;
+    isAuthRequired: number;
+  };
+ }
+ 


### PR DESCRIPTION
무엇을 위한 PR인가요?
- [x] 신규 기능 추가 : 설정페이지 화면 및 api연동
- [ ] 버그 수정 :
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 :

변경사항 및 이유
유저의 설정값들을 변경할 수 있는 페이지

작업 내역
<img width="895" alt="image" src="https://github.com/user-attachments/assets/6d0307e4-ef64-474a-b951-d49b958f9ab5">

PR 특이 사항
- 추후 통신 실패시 toast mesaage나타나게 구현할 예정

Issue Number
close: #
어떤 부분에 리뷰어가 집중하면 좋을까요?
