### PR TITLE
feat: add token setting and store setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "react-router-dom": "5.3.4",
     "tailwind-merge": "^2.5.5",
     "tailwindcss-animate": "^1.0.7",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "zustand": "^5.0.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.15.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ importers:
       zod:
         specifier: ^3.23.8
         version: 3.23.8
+      zustand:
+        specifier: ^5.0.2
+        version: 5.0.2(@types/react@18.3.14)(react@18.3.1)
     devDependencies:
       '@eslint/js':
         specifier: ^9.15.0
@@ -1978,6 +1981,24 @@ packages:
   zod@3.23.8:
     resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
 
+  zustand@5.0.2:
+    resolution: {integrity: sha512-8qNdnJVJlHlrKXi50LDqqUNmUbuBjoKLrYQBnoChIbVph7vni+sY+YpvdjXG9YLd/Bxr6scMcR+rm5H3aSqPaw==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
+
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
@@ -3733,3 +3754,8 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   zod@3.23.8: {}
+
+  zustand@5.0.2(@types/react@18.3.14)(react@18.3.1):
+    optionalDependencies:
+      '@types/react': 18.3.14
+      react: 18.3.1

--- a/src/api/answer/index.ts
+++ b/src/api/answer/index.ts
@@ -13,7 +13,7 @@ export const answerAPI = {
   list: async (
     param: T.GetAnswerListParam
   ): Promise<AxiosResponse<T.GetAnswerListResponse>> => {
-    const res = await api.get(`answer/${param.memberId}/list`);
+    const res = await api.get(`answer/${param.userId}/list`);
 
     return res;
   },
@@ -30,9 +30,9 @@ export const answerAPI = {
     return res;
   },
   getSelfReflectionAnswer: async (
-    memberId: string
+    userId: number
   ): Promise<T.SelfReflectionAnswerResponse> => {
-    const res = await api.get(`/self-reflection/${memberId}/list`);
+    const res = await api.get(`/self-reflection/${userId}/list`);
     return res.data;
   },
 };

--- a/src/api/answer/type.ts
+++ b/src/api/answer/type.ts
@@ -20,7 +20,7 @@ export type AnswerCreateResponse = BaseResponse<{
 export type SelfReflectionAnswerResponse = BaseResponse<SelfReflection>;
 
 export type GetAnswerListParam = {
-  memberId: number;
+  userId: number;
 };
 
 export type GetAnswerListResponse = BaseResponse<{

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,4 +1,8 @@
-import axios, { AxiosInstance } from "axios";
+import axios, {
+  AxiosHeaders,
+  AxiosInstance,
+  InternalAxiosRequestConfig,
+} from "axios";
 
 const BASE_URL: string = import.meta.env.VITE_API_HOST;
 const VERSION = import.meta.env.VITE_API_VERSION;
@@ -13,5 +17,26 @@ const createAxios = (): AxiosInstance => {
   return axios.create({ baseURL: BASE_URL + VERSION, headers: HEADERS });
 };
 
+// TODO: token 세팅 후 코드 수정 필요
+const token = "";
+const interceptors = (instance: AxiosInstance): AxiosInstance => {
+  instance.interceptors.request.use(
+    async (config: InternalAxiosRequestConfig) => {
+      if (!config.headers) {
+        config.headers = new AxiosHeaders();
+      }
+      config.headers.Authorization = `Bearer ${token}`;
+      return config;
+    },
+    (error) => {
+      return Promise.reject(error);
+    }
+  );
+  return instance;
+};
+
 // No token
-export const api: AxiosInstance = createAxios();
+export const api = createAxios();
+
+// With token
+export const apiWithToken = interceptors(api);

--- a/src/api/link/index.ts
+++ b/src/api/link/index.ts
@@ -2,11 +2,11 @@ import * as T from "./type";
 import { api } from "..";
 
 export async function getLink(
-  questionId: string,
-  memberId: string,
+  questionId: number,
+  userId: number,
   params: T.ShareLinkParam
 ): Promise<T.ShareLinkResponse> {
-  const res = await api.get(`/question/${questionId}/share-info/${memberId}`, {
+  const res = await api.get(`/question/${questionId}/share-info/${userId}`, {
     params,
   });
   return res.data;

--- a/src/api/member/index.ts
+++ b/src/api/member/index.ts
@@ -18,9 +18,9 @@ export const memberAPI = {
     return res;
   },
   search: async (
-    memberId: string
+    userId: number
   ): Promise<AxiosResponse<T.MemberSearchResponse>> => {
-    const res = await api.get(`/member/${memberId}`);
+    const res = await api.get(`/member/${userId}`);
 
     return res;
   },

--- a/src/api/self-reflection/index.ts
+++ b/src/api/self-reflection/index.ts
@@ -3,25 +3,21 @@ import { api } from "..";
 import * as T from "./type";
 
 export const selfReflection = {
-  getCommonQuestions: async (
-    memberId: string
-  ): Promise<AxiosResponse<T.QuestionResponse>> => {
-    return api.get("/self-reflection/common-question", {
-      params: { memberId },
-    });
+  getCommonQuestions: async (): Promise<AxiosResponse<T.QuestionResponse>> => {
+    return api.get("/self-reflection/common-question");
   },
 
   getSelfReflection: async (
-    memberId: string
+    userId: number
   ): Promise<AxiosResponse<T.GetReflectionAnswerResponse>> => {
-    return api.get(`/self-reflection/${memberId}/list`);
+    return api.get(`/self-reflection/${userId}/list`);
   },
 
   submitReflections: async (
-    memberId: string,
+    userId: number,
     reflections: T.ReflectionRequest[]
   ) => {
-    return api.post(`/self-reflection/${memberId}`, {
+    return api.post(`/self-reflection/${userId}`, {
       reflections,
     });
   },

--- a/src/api/settings/index.ts
+++ b/src/api/settings/index.ts
@@ -4,15 +4,15 @@ import { api } from "@/api";
 
 export const userInfo = {
   getSettings: async (
-    memberId: string
+    userId: number
   ): Promise<AxiosResponse<MemberResponse>> => {
-    return api.get(`/member/${memberId}`);
+    return api.get(`/member/${userId}`);
   },
 
   updateSettings: async (
-    memberId: string,
+    userId: number,
     settings: MemberSettings
   ): Promise<AxiosResponse<MemberResponse>> => {
-    return api.put(`/member/${memberId}`, settings);
+    return api.put(`/member/${userId}`, settings);
   },
 };

--- a/src/components/common/snowFall.tsx
+++ b/src/components/common/snowFall.tsx
@@ -1,5 +1,7 @@
-import { answerAPI } from "@/api/answer";
 import { useEffect, useState } from "react";
+import { answerAPI } from "@/api/answer";
+
+import { useUserStore } from "@/store/userStore";
 
 const Snowfall = () => {
   const snowflakes = Array.from({ length: 50 });
@@ -17,9 +19,9 @@ const Snowfall = () => {
     });
   };
 
-  const userId = Number(localStorage.getItem("userId"));
+  const { userId } = useUserStore();
   useEffect(() => {
-    handleSnowflakeColor(userId);
+    if (userId) handleSnowflakeColor(userId);
   }, [userId]);
 
   return (

--- a/src/components/common/snowFall.tsx
+++ b/src/components/common/snowFall.tsx
@@ -8,8 +8,8 @@ const Snowfall = () => {
 
   const [snowColorArray, setSnowColorArray] = useState<string[]>([]);
 
-  const handleSnowflakeColor = async (memberId: number) => {
-    await answerAPI.list({ memberId }).then((res) => {
+  const handleSnowflakeColor = async (userId: number) => {
+    await answerAPI.list({ userId }).then((res) => {
       const data = res.data.data;
 
       const colorArr = data.list?.map((answer) => answer.colorCode);

--- a/src/components/display/DirectLogin.tsx
+++ b/src/components/display/DirectLogin.tsx
@@ -15,7 +15,7 @@ export function DirectLogin() {
         onClick={() =>
           history.push({
             pathname: "/member-login",
-            state: { memberId: DUMMY_MEMBER_ID },
+            state: { userId: DUMMY_MEMBER_ID },
           })
         }
       >

--- a/src/components/share/ShareButton.tsx
+++ b/src/components/share/ShareButton.tsx
@@ -6,27 +6,21 @@ import { SHARE_LINK_PARAM } from "@/constant/link";
 
 type Props = {
   className?: string;
-  memberId: number;
+  userId: number;
   questionId: number;
 };
 
-export default function ShareButton({
-  className,
-  memberId,
-  questionId,
-}: Props) {
+export default function ShareButton({ className, userId, questionId }: Props) {
   const { toast } = useToast();
 
   const copyShareLinkAddress = () => {
-    getLink(String(questionId), String(memberId), SHARE_LINK_PARAM).then(
-      (data) => {
-        navigator.clipboard.writeText(data.data.url).then(() => {
-          toast({
-            description: "링크가 복사되었습니다",
-          });
+    getLink(questionId, userId, SHARE_LINK_PARAM).then((data) => {
+      navigator.clipboard.writeText(data.data.url).then(() => {
+        toast({
+          description: "링크가 복사되었습니다",
         });
-      }
-    );
+      });
+    });
   };
 
   return (

--- a/src/hooks/useSelfReflection.ts
+++ b/src/hooks/useSelfReflection.ts
@@ -3,7 +3,7 @@ import { answerAPI } from "@/api/answer";
 import { SelfReflection } from "@/types/self-reflection";
 import { useToast } from "@/hooks/use-toast";
 
-export function useSelfReflection(memberId: string) {
+export function useSelfReflection(userId: number) {
   const [selfReflection, setSelfReflection] = useState<SelfReflection>([]);
   const [isLoading, setIsLoading] = useState(true);
   const { toast } = useToast();
@@ -11,7 +11,7 @@ export function useSelfReflection(memberId: string) {
   useEffect(() => {
     const fetchSelfReflection = async () => {
       try {
-        const response = await answerAPI.getSelfReflectionAnswer(memberId);
+        const response = await answerAPI.getSelfReflectionAnswer(userId);
         setSelfReflection(response.data);
       } catch (error) {
         toast({
@@ -25,7 +25,7 @@ export function useSelfReflection(memberId: string) {
     };
 
     fetchSelfReflection();
-  }, [memberId]);
+  }, [userId, toast]);
 
   return {
     selfReflection,

--- a/src/pages/answer-create/index.tsx
+++ b/src/pages/answer-create/index.tsx
@@ -44,12 +44,12 @@ export default function AnswerCreate() {
   }
 
   const sendAnswer = async () => {
-    await memberAPI.search(String(userId)).then((res) => {
+    await memberAPI.search(userId).then((res) => {
       const userInfo = res.data.data;
       setUserNicname(userInfo.nickname);
 
       answerAPI.create({
-        memberId: Number(userId),
+        memberId: userId,
         questionId: questionId,
         nickname: userNickname,
         sender: senderName,

--- a/src/pages/answer-create/index.tsx
+++ b/src/pages/answer-create/index.tsx
@@ -1,4 +1,8 @@
+import { useState, useMemo } from "react";
 import { useLocation } from "react-router-dom";
+
+import { answerAPI } from "@/api/answer";
+import { memberAPI } from "@/api/member";
 
 import { ColorPicker } from "@/components/color/ColorPicker";
 import {
@@ -6,15 +10,15 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
-import { MOCK_MEMBER } from "../_mock/data/member";
-import { useState, useMemo } from "react";
+import UnderlineInput from "@/components/input/UnderlineInput";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
-import UnderlineInput from "@/components/input/UnderlineInput";
-import { COLOR_CODE_LIST } from "@/constant/color";
-import { answerAPI } from "@/api/answer";
 import { DirectLogin } from "@/components/display/DirectLogin";
-import { memberAPI } from "@/api/member";
+
+import { MOCK_MEMBER } from "../_mock/data/member";
+import { COLOR_CODE_LIST } from "@/constant/color";
+
+import { useUserStore } from "@/store/userStore";
 
 function useQuery() {
   const { search } = useLocation();
@@ -23,7 +27,7 @@ function useQuery() {
 
 export default function AnswerCreate() {
   const query = useQuery();
-  // const memberId = query.get("memberId") as string;
+
   const questionId = query.get("questionId") as string;
 
   const [colorCode, setColorCode] = useState<string | undefined>(undefined);
@@ -31,19 +35,19 @@ export default function AnswerCreate() {
   const [userNickname, setUserNicname] = useState<string>("");
   const [senderName, setSenderName] = useState<string>("");
 
-  const storedId = localStorage.getItem("userId");
+  const { userId } = useUserStore();
 
-  if (!storedId) {
+  if (!userId) {
     return <DirectLogin />;
   }
 
   const sendAnswer = async () => {
-    await memberAPI.search(storedId).then((res) => {
+    await memberAPI.search(String(userId)).then((res) => {
       const userInfo = res.data.data;
       setUserNicname(userInfo.nickname);
 
       answerAPI.create({
-        memberId: Number(storedId),
+        memberId: Number(userId),
         questionId: questionId,
         nickname: userNickname,
         sender: senderName,

--- a/src/pages/answer-create/index.tsx
+++ b/src/pages/answer-create/index.tsx
@@ -28,6 +28,7 @@ function useQuery() {
 export default function AnswerCreate() {
   const query = useQuery();
 
+  // TODO: questionId로 질문 정보 조회하는 api 연결 필요
   const questionId = query.get("questionId") as string;
 
   const [colorCode, setColorCode] = useState<string | undefined>(undefined);
@@ -38,6 +39,7 @@ export default function AnswerCreate() {
   const { userId } = useUserStore();
 
   if (!userId) {
+    // TODO: 추후 질문에 설정된 옵션에 따라 login 체크 여부 나뉘도록 설정 필요
     return <DirectLogin />;
   }
 

--- a/src/pages/answer-result/index.tsx
+++ b/src/pages/answer-result/index.tsx
@@ -6,6 +6,8 @@ import AnswerDetailDialog from "@/components/answer/dialog/AnswerDetailDialog";
 import { answerAPI } from "@/api/answer";
 import { Answer } from "@/types/answer";
 
+import { useUserStore } from "@/store/userStore";
+
 export default function AnswerResult() {
   const [isDetailDialogOpen, setIsDetailDialogOpen] = useState(false);
   const [selectedItem, setSelectedItem] = useState<Answer | null>(null);
@@ -22,9 +24,9 @@ export default function AnswerResult() {
     });
   };
 
-  const userId = Number(localStorage.getItem("userId"));
+  const { userId } = useUserStore();
   useEffect(() => {
-    getAnswersData(userId);
+    if (userId) getAnswersData(userId);
   }, [userId]);
 
   const handleDialogToggle = (marble?: Answer) => {
@@ -37,7 +39,7 @@ export default function AnswerResult() {
 
   const handleDeleteSuccess = () => {
     handleDialogToggle();
-    getAnswersData(userId);
+    if (userId) getAnswersData(userId);
   };
 
   return (

--- a/src/pages/answer-result/index.tsx
+++ b/src/pages/answer-result/index.tsx
@@ -14,8 +14,8 @@ export default function AnswerResult() {
 
   const [answersData, setAnswersData] = useState<Answer[]>();
 
-  const getAnswersData = async (memberId: number) => {
-    await answerAPI.list({ memberId: memberId }).then((res) => {
+  const getAnswersData = async (userId: number) => {
+    await answerAPI.list({ userId }).then((res) => {
       const data = res.data;
 
       if (data.status === "OK" && data.data.list) {

--- a/src/pages/main/components/ReflectionButton.tsx
+++ b/src/pages/main/components/ReflectionButton.tsx
@@ -3,12 +3,12 @@ import { useSelfReflection } from "@/hooks/useSelfReflection";
 import { useHistory } from "react-router-dom";
 
 type ReflectionButtonProps = {
-  memberId: string;
+  userId: number;
 };
 
-export function ReflectionButton({ memberId }: ReflectionButtonProps) {
+export function ReflectionButton({ userId }: ReflectionButtonProps) {
   const history = useHistory();
-  const { hasReflection, isLoading } = useSelfReflection(memberId);
+  const { hasReflection, isLoading } = useSelfReflection(userId);
 
   if (isLoading) return null;
 

--- a/src/pages/main/components/WithAnswer.tsx
+++ b/src/pages/main/components/WithAnswer.tsx
@@ -6,13 +6,13 @@ import { Button } from "@/components/ui/button";
 type Props = {
   answerCount: number;
   previewMessage: Answer;
-  memberId: string;
+  userId: number;
 };
 
 export default function WithAnswer({
   answerCount,
   previewMessage,
-  memberId,
+  userId,
 }: Props) {
   return (
     <div className="flex flex-col items-center">
@@ -32,7 +32,7 @@ export default function WithAnswer({
         공유하기 버튼은 추후 개발 예정이에요!
       </span>
       <Button disabled className="mb-2 w-24" children="공유" />
-      <ReflectionButton memberId={memberId} />
+      <ReflectionButton userId={userId} />
     </div>
   );
 }

--- a/src/pages/main/components/WithoutAnswer.tsx
+++ b/src/pages/main/components/WithoutAnswer.tsx
@@ -3,10 +3,10 @@ import { BUNDEL_IMAGE_URL } from "@/constant/image";
 import { ReflectionButton } from "@/pages/main/components/ReflectionButton";
 
 type Props = {
-  memberId: string;
+  userId: number;
 };
 
-export default function WithoutAnswer({ memberId }: Props) {
+export default function WithoutAnswer({ userId }: Props) {
   return (
     <div className="flex flex-col items-center">
       <span>어떤 쪽지들이 담길까요?</span>
@@ -20,7 +20,7 @@ export default function WithoutAnswer({ memberId }: Props) {
         공유하기 버튼은 추후 개발 예정이에요!
       </span>
       <Button disabled className="mb-2 w-24" children="공유" />
-      <ReflectionButton memberId={memberId} />
+      <ReflectionButton userId={userId} />
     </div>
   );
 }

--- a/src/pages/main/index.tsx
+++ b/src/pages/main/index.tsx
@@ -1,30 +1,28 @@
 import { useState, useEffect } from "react";
 
+import { answerAPI } from "../../api/answer";
+
 import { getRandomIndex } from "@/lib/utils";
 import { Answer } from "@/types/answer";
 
 import WithoutAnswer from "./components/WithoutAnswer";
 import WithAnswer from "./components/WithAnswer";
 import NonLoggedSection from "./components/NonLoggedSection";
-import { answerAPI } from "../../api/answer";
-import { MEMBER_ID_KEY } from "@/constant/keys";
+
+import { useUserStore } from "@/store/userStore";
 
 export default function Main() {
   const [memberId, setMemberId] = useState<string>();
   const [answers, setAnswers] = useState<Answer[]>([]);
   const [nickname, setNickname] = useState<string>("");
 
+  const { userId } = useUserStore();
+
   useEffect(() => {
-    const checkLocalStorage = () => {
-      const userId = localStorage.getItem(MEMBER_ID_KEY);
-
-      if (userId) {
-        setMemberId(userId);
-      }
-    };
-
-    checkLocalStorage();
-  }, []);
+    if (userId) {
+      setMemberId(String(userId));
+    }
+  }, [userId]);
 
   useEffect(() => {
     if (memberId) {

--- a/src/pages/main/index.tsx
+++ b/src/pages/main/index.tsx
@@ -12,7 +12,6 @@ import NonLoggedSection from "./components/NonLoggedSection";
 import { useUserStore } from "@/store/userStore";
 
 export default function Main() {
-  const [memberId, setMemberId] = useState<string>();
   const [answers, setAnswers] = useState<Answer[]>([]);
   const [nickname, setNickname] = useState<string>("");
 
@@ -20,13 +19,7 @@ export default function Main() {
 
   useEffect(() => {
     if (userId) {
-      setMemberId(String(userId));
-    }
-  }, [userId]);
-
-  useEffect(() => {
-    if (memberId) {
-      answerAPI.list({ memberId: Number(memberId) }).then((res) => {
+      answerAPI.list({ userId }).then((res) => {
         const data = res.data;
         if (data.data.list?.length) {
           setAnswers(data.data.list);
@@ -34,11 +27,11 @@ export default function Main() {
         setNickname(data.data.nickname);
       });
     }
-  }, [memberId]);
+  }, [userId]);
 
   const answerCount = answers.length;
   const previewMessage = answers[getRandomIndex(answers)];
-  const hasUserId = memberId != null;
+  const hasUserId = userId != null;
 
   return (
     <>
@@ -48,10 +41,10 @@ export default function Main() {
         <section className="flex flex-col justify-center items-center h-screen">
           <h2 className="font-bold text-2xl mb-2">{nickname}님의 보따리</h2>
           {answerCount < 1 ? (
-            <WithoutAnswer memberId={memberId} />
+            <WithoutAnswer userId={userId} />
           ) : (
             <WithAnswer
-              memberId={memberId}
+              userId={userId}
               answerCount={answerCount}
               previewMessage={previewMessage}
             />

--- a/src/pages/member-login/index.tsx
+++ b/src/pages/member-login/index.tsx
@@ -20,10 +20,10 @@ import {
 import { Input } from "@/components/ui/input";
 
 export default function MemberLogin() {
-  const { state } = useLocation<{ memberId: number; questionId: number }>();
+  const { state } = useLocation<{ userId: number; questionId: number }>();
   const [errorMessage, setErrorMessage] = useState<string>();
 
-  const { setUser } = useUserStore();
+  const { setUserId } = useUserStore();
 
   console.log(state);
   const history = useHistory();
@@ -40,13 +40,14 @@ export default function MemberLogin() {
       const data = res.data;
 
       if (data.status === "OK") {
-        setUser(data.data.id);
+        // store에 userId 저장
+        setUserId(data.data.id);
 
-        if (state?.memberId && state?.questionId) {
+        if (state?.userId && state?.questionId) {
           // COMMENT: 답변 작성 페이지에서 로그인 페이지로 유도한 경우 로그인 성공시 다시 답변 페이지로 redirection
           history.push({
             pathname: "/answer",
-            search: `?memberId=${state.memberId}&questionId=${state.questionId}`,
+            search: `?userId=${state.userId}&questionId=${state.questionId}`,
           });
         } else {
           history.push("/main");

--- a/src/pages/member-login/index.tsx
+++ b/src/pages/member-login/index.tsx
@@ -43,6 +43,7 @@ export default function MemberLogin() {
         setUser(data.data.id);
 
         if (state?.memberId && state?.questionId) {
+          // COMMENT: 답변 작성 페이지에서 로그인 페이지로 유도한 경우 로그인 성공시 다시 답변 페이지로 redirection
           history.push({
             pathname: "/answer",
             search: `?memberId=${state.memberId}&questionId=${state.questionId}`,

--- a/src/pages/member-login/index.tsx
+++ b/src/pages/member-login/index.tsx
@@ -1,8 +1,11 @@
+import { useState } from "react";
 import { useHistory, useLocation } from "react-router-dom";
 import { useForm } from "react-hook-form";
 
 import { memberAPI } from "@/api/member";
 import { MemberLoginParam } from "@/api/member/type";
+
+import { useUserStore } from "@/store/userStore";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -15,11 +18,12 @@ import {
   FormDescription,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
-import { useState } from "react";
 
 export default function MemberLogin() {
   const { state } = useLocation<{ memberId: number; questionId: number }>();
   const [errorMessage, setErrorMessage] = useState<string>();
+
+  const { setUser } = useUserStore();
 
   console.log(state);
   const history = useHistory();
@@ -36,7 +40,7 @@ export default function MemberLogin() {
       const data = res.data;
 
       if (data.status === "OK") {
-        localStorage.setItem("userId", String(data.data.id));
+        setUser(data.data.id);
 
         if (state?.memberId && state?.questionId) {
           history.push({

--- a/src/pages/question-create-complete/index.tsx
+++ b/src/pages/question-create-complete/index.tsx
@@ -34,7 +34,7 @@ export default function QuestionCreateComplete() {
 
       <div className="flex gap-1">
         <Button onClick={() => history.push("/main")}>메인 이동</Button>
-        <ShareButton memberId={userId} questionId={state.questionId} />
+        <ShareButton userId={userId} questionId={state.questionId} />
       </div>
     </div>
   );

--- a/src/pages/question-create-complete/index.tsx
+++ b/src/pages/question-create-complete/index.tsx
@@ -1,16 +1,20 @@
+import { useLocation, useHistory } from "react-router-dom";
+
 import { DirectLogin } from "@/components/display/DirectLogin";
 import ShareButton from "@/components/share/ShareButton";
 import { Button } from "@/components/ui/button";
+
 import { BUNDEL_IMAGE_URL } from "@/constant/image";
-import { MEMBER_ID_KEY } from "@/constant/keys";
-import { useLocation, useHistory } from "react-router-dom";
+
+import { useUserStore } from "@/store/userStore";
 
 export default function QuestionCreateComplete() {
   const { state } = useLocation<{ questionId: number }>();
   const history = useHistory();
-  const memberId = localStorage.getItem(MEMBER_ID_KEY);
 
-  if (!memberId || !state.questionId) {
+  const { userId } = useUserStore();
+
+  if (!userId || !state.questionId) {
     return <DirectLogin />;
   }
 
@@ -30,10 +34,7 @@ export default function QuestionCreateComplete() {
 
       <div className="flex gap-1">
         <Button onClick={() => history.push("/main")}>메인 이동</Button>
-        <ShareButton
-          memberId={Number(memberId)}
-          questionId={state.questionId}
-        />
+        <ShareButton memberId={userId} questionId={state.questionId} />
       </div>
     </div>
   );

--- a/src/pages/question-create-detail/index.tsx
+++ b/src/pages/question-create-detail/index.tsx
@@ -1,25 +1,29 @@
+import { useLocation, useHistory } from "react-router-dom";
+
 import { questionAPI } from "@/api/question";
 import { DirectLogin } from "@/components/display/DirectLogin";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
+
 import { BUNDEL_IMAGE_URL } from "@/constant/image";
-import { MEMBER_ID_KEY } from "@/constant/keys";
-import { useLocation, useHistory } from "react-router-dom";
+
+import { useUserStore } from "@/store/userStore";
 
 export default function QuestionCreateDetail() {
   const { state } = useLocation<{ content: string }>();
-  const memberId = localStorage.getItem(MEMBER_ID_KEY);
   const history = useHistory();
 
-  if (!memberId) {
+  const { userId } = useUserStore();
+
+  if (!userId) {
     return <DirectLogin />;
   }
 
   const handleClick = () => {
     questionAPI
       .create({
-        memberId: Number(memberId),
+        memberId: userId,
         content: state?.content ?? "",
         isPublicVisible: 1,
         isCountVisible: 1,

--- a/src/pages/self-reflection/index.tsx
+++ b/src/pages/self-reflection/index.tsx
@@ -24,6 +24,8 @@ import {
 } from "@/api/self-reflection/type";
 import ReadOnlyReflection from "@/pages/self-reflection/ReadOnlyReflection";
 
+import { useUserStore } from "@/store/userStore";
+
 const DESCRIPTION = {
   WRITE: "수정이 불가능하니 나를 깊게 돌아봐주세요",
   READ: "이전에 작성한 나의 회고입니다",
@@ -71,7 +73,7 @@ export default function SelfReflection() {
   );
 
   const history = useHistory();
-  const userId = localStorage.getItem("userId");
+  const { userId } = useUserStore();
 
   const form = useForm<z.infer<typeof selfReflectionSchema>>({
     resolver: zodResolver(selfReflectionSchema),
@@ -83,24 +85,6 @@ export default function SelfReflection() {
       message2025: "",
     },
   });
-
-  const fetchQuestions = async () => {
-    if (!userId) return;
-    try {
-      const [questionsRes, answersRes] = await Promise.all([
-        selfReflection.getCommonQuestions(userId),
-        selfReflection.getSelfReflection(userId),
-      ]);
-      setQuestions(questionsRes.data.data);
-      setExistingAnswers(answersRes.data.data);
-    } catch (error) {
-      toast({
-        variant: "destructive",
-        title: "질문 로딩 실패",
-        description: "질문을 불러오는데 실패했습니다. 다시 시도해주세요.",
-      });
-    }
-  };
 
   function onSubmit() {
     setShowConfirmModal(true);
@@ -119,7 +103,7 @@ export default function SelfReflection() {
     ].filter((item) => item.questionId);
 
     try {
-      await selfReflection.submitReflections(userId, reflections);
+      await selfReflection.submitReflections(String(userId), reflections);
       toast({
         title: "제출 완료",
         description: "회고가 성공적으로 저장되었습니다.",
@@ -137,10 +121,28 @@ export default function SelfReflection() {
   };
 
   useEffect(() => {
+    const fetchQuestions = async () => {
+      if (!userId) return;
+      try {
+        const [questionsRes, answersRes] = await Promise.all([
+          selfReflection.getCommonQuestions(String(userId)),
+          selfReflection.getSelfReflection(String(userId)),
+        ]);
+        setQuestions(questionsRes.data.data);
+        setExistingAnswers(answersRes.data.data);
+      } catch (error) {
+        toast({
+          variant: "destructive",
+          title: "질문 로딩 실패",
+          description: "질문을 불러오는데 실패했습니다. 다시 시도해주세요.",
+        });
+      }
+    };
+
     if (userId) {
       fetchQuestions();
     }
-  }, [userId]);
+  }, [userId, toast]);
 
   return (
     <div className="w-full">

--- a/src/pages/self-reflection/index.tsx
+++ b/src/pages/self-reflection/index.tsx
@@ -103,7 +103,7 @@ export default function SelfReflection() {
     ].filter((item) => item.questionId);
 
     try {
-      await selfReflection.submitReflections(String(userId), reflections);
+      await selfReflection.submitReflections(userId, reflections);
       toast({
         title: "제출 완료",
         description: "회고가 성공적으로 저장되었습니다.",
@@ -125,8 +125,8 @@ export default function SelfReflection() {
       if (!userId) return;
       try {
         const [questionsRes, answersRes] = await Promise.all([
-          selfReflection.getCommonQuestions(String(userId)),
-          selfReflection.getSelfReflection(String(userId)),
+          selfReflection.getCommonQuestions(),
+          selfReflection.getSelfReflection(userId),
         ]);
         setQuestions(questionsRes.data.data);
         setExistingAnswers(answersRes.data.data);

--- a/src/pages/settings/index.tsx
+++ b/src/pages/settings/index.tsx
@@ -4,8 +4,11 @@ import { Label } from "@/components/ui/label";
 import { MemberSettings } from "@/types/member";
 import { userInfo } from "@/api/settings";
 
+import { useUserStore } from "@/store/userStore";
+
 export default function Settings() {
-  const memberId = "9"; // 임시 memberId
+  const { userId } = useUserStore();
+
   const [settings, setSettings] = useState<MemberSettings>({
     isPublicVisible: 0,
     isCountVisible: 0,
@@ -19,27 +22,28 @@ export default function Settings() {
     };
 
     try {
-      await userInfo.updateSettings(memberId, newSettings);
+      if (userId) await userInfo.updateSettings(userId, newSettings);
       setSettings(newSettings);
     } catch (error) {
       setSettings(settings);
     }
   };
 
-  const fetchSettings = async () => {
-    try {
-      const response = await userInfo.getSettings(memberId);
-      const { isPublicVisible, isCountVisible, isAuthRequired } =
-        response.data.data;
-      setSettings({ isPublicVisible, isCountVisible, isAuthRequired });
-    } catch (error) {
-      console.error("설정을 불러오는데 실패했습니다.");
-    }
-  };
-
   useEffect(() => {
+    const fetchSettings = async () => {
+      try {
+        if (userId) {
+          const response = await userInfo.getSettings(userId);
+          const { isPublicVisible, isCountVisible, isAuthRequired } =
+            response.data.data;
+          setSettings({ isPublicVisible, isCountVisible, isAuthRequired });
+        }
+      } catch (error) {
+        console.error("설정을 불러오는데 실패했습니다.");
+      }
+    };
     fetchSettings();
-  }, [memberId]);
+  }, [userId]);
 
   return (
     <div>

--- a/src/routes/PrivateRoute.tsx
+++ b/src/routes/PrivateRoute.tsx
@@ -1,13 +1,15 @@
-import { MEMBER_ID_KEY } from "@/constant/keys";
 import React from "react";
 import { Redirect, RouteProps } from "react-router-dom";
+
+import { useUserStore } from "@/store/userStore";
 
 interface PrivateRouteProps extends RouteProps {
   children: React.ReactNode;
 }
 
 export default function PrivateRoute({ children }: PrivateRouteProps) {
-  const isAuthenticated: boolean = !!localStorage.getItem(MEMBER_ID_KEY);
+  const { userId } = useUserStore();
+  const isAuthenticated: boolean = !!userId;
 
   if (isAuthenticated) {
     return children;

--- a/src/store/userStore.ts
+++ b/src/store/userStore.ts
@@ -1,0 +1,21 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+interface UserStore {
+  userId: number | null;
+  setUser: (user: number | null) => void;
+  clearUser: () => void;
+}
+
+export const useUserStore = create<UserStore>()(
+  persist(
+    (set) => ({
+      userId: null,
+      setUser: (user) => set({ userId: user }),
+      clearUser: () => set({ userId: null }),
+    }),
+    {
+      name: "user-storage",
+    }
+  )
+);

--- a/src/store/userStore.ts
+++ b/src/store/userStore.ts
@@ -3,7 +3,7 @@ import { persist } from "zustand/middleware";
 
 interface UserStore {
   userId: number | null;
-  setUser: (user: number | null) => void;
+  setUserId: (user: number | null) => void;
   clearUser: () => void;
 }
 
@@ -11,7 +11,7 @@ export const useUserStore = create<UserStore>()(
   persist(
     (set) => ({
       userId: null,
-      setUser: (user) => set({ userId: user }),
+      setUserId: (user) => set({ userId: user }),
       clearUser: () => set({ userId: null }),
     }),
     {


### PR DESCRIPTION
## 무엇을 위한 PR인가요?

- [x] 신규 기능 추가 : api interceptor
- [ ] 버그 수정 :
- [x] 리펙토링 : store
- [ ] 문서 업데이트 :
- [ ] 기타 :

## 변경사항 및 이유

- api setting에 token interceptor 추가
- store setting 추가
  - 기존 localStorage에 저장하던 userId 값을 store에 저장하도록 수정
  - setting 설정 페이지에서 임의 userId로 넣고 있던 param값을 로그인시 저장된 값을 가져와 호출하도록 수정
    - cc @hyjoong 

### PR 특이 사항

- zustand 설치
- 추후 api 수정이 이루어져 token이 들어오면 interceptor 쪽 변수값 수정 필요
  - 현재는 token이 리턴되지 않아 빈 스트링으로 설정

---

- 리뷰 이후 memberId를 userId로 네이밍 일치화 및 type을 number로 적용
  - 백엔드에서 post메소드의 key값을 memberId로 정해둔 경우를 제외하고 적용

## Issue Number

#15 