### PR TITLE
[BGRM-40, 41, 42] 답변 리스트, 답변 상세 dialog, 삭제 컴펀 dialog 디자인 반영 업데이트

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.54.0",
+    "react-icons": "^5.4.0",
     "react-router-dom": "5.3.4",
     "tailwind-merge": "^2.5.5",
     "tailwindcss-animate": "^1.0.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       react-hook-form:
         specifier: ^7.54.0
         version: 7.54.0(react@18.3.1)
+      react-icons:
+        specifier: ^5.4.0
+        version: 5.4.0(react@18.3.1)
       react-router-dom:
         specifier: 5.3.4
         version: 5.3.4(react@18.3.1)
@@ -1727,6 +1730,11 @@ packages:
     engines: {node: '>=18.0.0'}
     peerDependencies:
       react: ^16.8.0 || ^17 || ^18 || ^19
+
+  react-icons@5.4.0:
+    resolution: {integrity: sha512-7eltJxgVt7X64oHh6wSWNwwbKTCtMfK35hcjvJS0yxEAhPM8oUKdS3+kqaW1vicIltw+kR2unHaa12S9pPALoQ==}
+    peerDependencies:
+      react: '*'
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -3556,6 +3564,10 @@ snapshots:
       scheduler: 0.23.2
 
   react-hook-form@7.54.0(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+
+  react-icons@5.4.0(react@18.3.1):
     dependencies:
       react: 18.3.1
 

--- a/src/components/FunnelForm/FunnelForm.tsx
+++ b/src/components/FunnelForm/FunnelForm.tsx
@@ -1,4 +1,5 @@
-import { ChevronLeft, ChevronRight } from "lucide-react";
+import { IoIosArrowBack, IoIosArrowForward } from "react-icons/io";
+
 import { FieldValues, UseFormReturn } from "react-hook-form";
 import { Button } from "@/components/ui/button";
 import { Form } from "@/components/ui/form";
@@ -39,7 +40,7 @@ export function FunnelForm<T extends FieldValues>({
               className="w-full relative"
               onClick={onPrev}
             >
-              <ChevronLeft
+              <IoIosArrowBack
                 className="absolute left-4"
                 color="#667EF5"
                 size={14}
@@ -54,7 +55,7 @@ export function FunnelForm<T extends FieldValues>({
           ) : (
             <Button type="button" onClick={onNext} className="w-full relative">
               {`다음(${currentStep}/${totalSteps})`}
-              <ChevronRight
+              <IoIosArrowForward
                 className="absolute right-4"
                 size={132}
                 color="#FFFFFF"

--- a/src/components/answer/AnswerCard.tsx
+++ b/src/components/answer/AnswerCard.tsx
@@ -1,4 +1,3 @@
-import { hexToRgba } from "@/lib/colorTools";
 import { Answer } from "@/types/answer";
 
 interface Props {
@@ -7,14 +6,24 @@ interface Props {
 }
 
 export default function AnswerCard({ answer, onDialogOpen }: Props) {
+  const date = answer.regDate as string;
+
   return (
     <div>
-      <p className="font-bold">{answer.sender}님의 구슬</p>
-      {/** COMMENT: 사용자가 선택한 답변(구슬) 색상의 활용 여부는 추후 변경될 수 있습니다. e.g. 유저 이름, 배경 색 등 */}
+      <div className="flex justify-between  mb-1 text-white">
+        <span className="flex gap-2 font-semibold">
+          <div
+            style={{ backgroundColor: answer.colorCode }}
+            className="w-[24px] h-[24px] rounded-full"
+          ></div>
+          {answer.sender}님의 구슬
+        </span>
+        <span>{date}</span>
+      </div>
+
       <div
         onClick={onDialogOpen}
-        style={{ borderColor: hexToRgba(answer.colorCode, 0.4) }}
-        className="rounded-md border-2 min-h-20 p-3"
+        className="rounded-md border-2 min-h-20 p-3 bg-[#F3F3F3] font-nanum-dahaengce text-xl"
       >
         <p>{answer.content}</p>
       </div>

--- a/src/components/answer/AnswerList.tsx
+++ b/src/components/answer/AnswerList.tsx
@@ -1,5 +1,4 @@
 import { ScrollArea } from "../ui/scroll-area";
-
 import AnswerCard from "./AnswerCard";
 
 import { Answer } from "@/types/answer";
@@ -15,7 +14,7 @@ export default function AnswerList({ listData, onDialogOpen }: Props) {
 
   return (
     <ScrollArea className="h-[580px]">
-      <div className="flex flex-col gap-3 px-3">
+      <div className="flex flex-col gap-4 px-3">
         {Answer &&
           Answer.map((marble) => {
             return (

--- a/src/components/answer/dialog/AnswerDeleteDialog.tsx
+++ b/src/components/answer/dialog/AnswerDeleteDialog.tsx
@@ -7,7 +7,6 @@ import {
   AlertDialogDescription,
   AlertDialogFooter,
   AlertDialogHeader,
-  AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 
 type Props = {
@@ -36,18 +35,21 @@ export default function AnswerDeleteDialog({
   return (
     <AlertDialog open={isOpen} onOpenChange={onClose}>
       <AlertDialogContent>
-        <AlertDialogHeader>
-          <AlertDialogTitle>정말 구슬을 깨트릴까요?</AlertDialogTitle>
+        <AlertDialogHeader className="text-[24px] mt-3 mb-5">
+          <h2>
+            깨진 구슬은 <strong>복구할 수 없어요!</strong>
+          </h2>
+          <h2>정말 구슬을 깨트릴까요?</h2>
           <AlertDialogDescription>
-            <p>한 번 삭제된 구슬은 되돌릴 수 없어요!</p>
             <p>신중하게 결정하세요!</p>
           </AlertDialogDescription>
         </AlertDialogHeader>
+
         <AlertDialogFooter>
-          <AlertDialogCancel>취소</AlertDialogCancel>
           <AlertDialogAction onClick={() => handleDeleteAnswer(targetId)}>
             삭제
           </AlertDialogAction>
+          <AlertDialogCancel>취소</AlertDialogCancel>
         </AlertDialogFooter>
       </AlertDialogContent>
     </AlertDialog>

--- a/src/components/answer/dialog/AnswerDetailDialog.tsx
+++ b/src/components/answer/dialog/AnswerDetailDialog.tsx
@@ -1,9 +1,5 @@
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
+import { FaTrashAlt } from "react-icons/fa";
+import { Dialog, DialogContent, DialogFooter } from "@/components/ui/dialog";
 
 import { Button } from "../../ui/button";
 import { useState } from "react";
@@ -25,6 +21,7 @@ export default function AnswerDetailDialog({
   onDeleteSuccess,
 }: Props) {
   const [isDeleteAlertOpen, setIsDeleteDialogOpen] = useState(false);
+  const date = data.regDate as string;
 
   const handleDialogToggle = () => {
     setIsDeleteDialogOpen(!isDeleteAlertOpen);
@@ -37,14 +34,32 @@ export default function AnswerDetailDialog({
   return (
     <>
       <Dialog open={isOpen} onOpenChange={onClose}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>{data.sender}님의 구슬</DialogTitle>
-          </DialogHeader>
-          <p>{data.content}</p>
-          <Button onClick={handleDialogToggle} className="w-16 ml-auto">
-            삭제
-          </Button>
+        <DialogContent className="bg-[#D6D8E1]">
+          <div className="flex flex-row items-center justify-between mb-3">
+            <h2 className="flex gap-2 font-semibold">
+              <div
+                style={{ backgroundColor: data.colorCode }}
+                className="w-[24px] h-[24px] rounded-full"
+              ></div>
+              {data.sender}님의 구슬
+            </h2>
+
+            <span>{date}</span>
+          </div>
+
+          <p className="bg-[#F3F3F3] shadow-custom-inner rounded-xl py-2 px-4 min-h-[200px] mb-10 font-nanum-dahaengce text-xl">
+            {data.content}
+          </p>
+
+          <DialogFooter>
+            <Button onClick={handleDialogToggle}>닫기</Button>
+            <Button
+              onClick={handleDialogToggle}
+              className="bg-white text-primary"
+            >
+              <FaTrashAlt style={{ width: "20px", height: "auto" }} /> 삭제하기
+            </Button>
+          </DialogFooter>
         </DialogContent>
       </Dialog>
 

--- a/src/components/back-header/BackHeader.tsx
+++ b/src/components/back-header/BackHeader.tsx
@@ -1,5 +1,5 @@
 import { ReactNode } from "react";
-import { ArrowLeft } from "lucide-react";
+import { FaArrowLeft } from "react-icons/fa";
 import { cn } from "@/lib/utils";
 import { useHistory } from "react-router-dom";
 
@@ -17,7 +17,7 @@ export default function BackHeader({ children, className }: Props) {
   return (
     <header className={cn("relative", className)}>
       <button onClick={handleBack}>
-        <ArrowLeft size={32} color="#F0F0F0" />
+        <FaArrowLeft size={32} color="#F0F0F0" />
       </button>
       {children}
     </header>

--- a/src/components/share/ShareButton.tsx
+++ b/src/components/share/ShareButton.tsx
@@ -2,7 +2,7 @@ import { cn } from "@/lib/utils";
 import { Button, ButtonProps } from "../ui/button";
 import { getLink } from "@/api/link";
 import { useToast } from "@/hooks/use-toast";
-import { Link } from "lucide-react";
+import { FaLink } from "react-icons/fa6";
 import { SHARE_LINK_PARAM } from "@/constant/link";
 
 type Props = {
@@ -31,7 +31,7 @@ export default function ShareButton({ className, userId, children }: Props) {
 
   return (
     <Button onClick={copyShareLinkAddress} className={cn(className)}>
-      <Link />
+      <FaLink style={{ width: "24px", height: "auto" }} />
       {children}
     </Button>
   );

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -1,14 +1,14 @@
-import * as React from "react"
-import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog"
+import * as React from "react";
+import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog";
 
-import { cn } from "@/lib/utils"
-import { buttonVariants } from "@/components/ui/button"
+import { cn } from "@/lib/utils";
+import { buttonVariants } from "@/components/ui/button";
 
-const AlertDialog = AlertDialogPrimitive.Root
+const AlertDialog = AlertDialogPrimitive.Root;
 
-const AlertDialogTrigger = AlertDialogPrimitive.Trigger
+const AlertDialogTrigger = AlertDialogPrimitive.Trigger;
 
-const AlertDialogPortal = AlertDialogPrimitive.Portal
+const AlertDialogPortal = AlertDialogPrimitive.Portal;
 
 const AlertDialogOverlay = React.forwardRef<
   React.ElementRef<typeof AlertDialogPrimitive.Overlay>,
@@ -22,8 +22,8 @@ const AlertDialogOverlay = React.forwardRef<
     {...props}
     ref={ref}
   />
-))
-AlertDialogOverlay.displayName = AlertDialogPrimitive.Overlay.displayName
+));
+AlertDialogOverlay.displayName = AlertDialogPrimitive.Overlay.displayName;
 
 const AlertDialogContent = React.forwardRef<
   React.ElementRef<typeof AlertDialogPrimitive.Content>,
@@ -34,42 +34,37 @@ const AlertDialogContent = React.forwardRef<
     <AlertDialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed inset-x-0 bottom-0 z-50",
+        "w-full max-w-lg p-6 mx-auto",
+        "border rounded-[40px_40px_0_0]",
+        "bg-background shadow-lg",
+        "data-[state=open]:animate-slide-up data-[state=closed]:animate-slide-down",
         className
       )}
       {...props}
     />
   </AlertDialogPortal>
-))
-AlertDialogContent.displayName = AlertDialogPrimitive.Content.displayName
+));
+AlertDialogContent.displayName = AlertDialogPrimitive.Content.displayName;
 
 const AlertDialogHeader = ({
   className,
   ...props
 }: React.HTMLAttributes<HTMLDivElement>) => (
   <div
-    className={cn(
-      "flex flex-col space-y-2 text-center sm:text-left",
-      className
-    )}
+    className={cn("flex flex-col space-y-2 text-center", className)}
     {...props}
   />
-)
-AlertDialogHeader.displayName = "AlertDialogHeader"
+);
+AlertDialogHeader.displayName = "AlertDialogHeader";
 
 const AlertDialogFooter = ({
   className,
   ...props
 }: React.HTMLAttributes<HTMLDivElement>) => (
-  <div
-    className={cn(
-      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
-      className
-    )}
-    {...props}
-  />
-)
-AlertDialogFooter.displayName = "AlertDialogFooter"
+  <div className={cn("flex flex-col", className)} {...props} />
+);
+AlertDialogFooter.displayName = "AlertDialogFooter";
 
 const AlertDialogTitle = React.forwardRef<
   React.ElementRef<typeof AlertDialogPrimitive.Title>,
@@ -80,8 +75,8 @@ const AlertDialogTitle = React.forwardRef<
     className={cn("text-lg font-semibold", className)}
     {...props}
   />
-))
-AlertDialogTitle.displayName = AlertDialogPrimitive.Title.displayName
+));
+AlertDialogTitle.displayName = AlertDialogPrimitive.Title.displayName;
 
 const AlertDialogDescription = React.forwardRef<
   React.ElementRef<typeof AlertDialogPrimitive.Description>,
@@ -92,9 +87,9 @@ const AlertDialogDescription = React.forwardRef<
     className={cn("text-sm text-muted-foreground", className)}
     {...props}
   />
-))
+));
 AlertDialogDescription.displayName =
-  AlertDialogPrimitive.Description.displayName
+  AlertDialogPrimitive.Description.displayName;
 
 const AlertDialogAction = React.forwardRef<
   React.ElementRef<typeof AlertDialogPrimitive.Action>,
@@ -105,8 +100,8 @@ const AlertDialogAction = React.forwardRef<
     className={cn(buttonVariants(), className)}
     {...props}
   />
-))
-AlertDialogAction.displayName = AlertDialogPrimitive.Action.displayName
+));
+AlertDialogAction.displayName = AlertDialogPrimitive.Action.displayName;
 
 const AlertDialogCancel = React.forwardRef<
   React.ElementRef<typeof AlertDialogPrimitive.Cancel>,
@@ -114,15 +109,11 @@ const AlertDialogCancel = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <AlertDialogPrimitive.Cancel
     ref={ref}
-    className={cn(
-      buttonVariants({ variant: "outline" }),
-      "mt-2 sm:mt-0",
-      className
-    )}
+    className={cn(buttonVariants({ variant: "secondary" }), "mt-2", className)}
     {...props}
   />
-))
-AlertDialogCancel.displayName = AlertDialogPrimitive.Cancel.displayName
+));
+AlertDialogCancel.displayName = AlertDialogPrimitive.Cancel.displayName;
 
 export {
   AlertDialog,
@@ -136,4 +127,4 @@ export {
   AlertDialogDescription,
   AlertDialogAction,
   AlertDialogCancel,
-}
+};

--- a/src/features/settings/SettingsSheet.tsx
+++ b/src/features/settings/SettingsSheet.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { Settings } from "lucide-react";
+import { IoMdSettings } from "react-icons/io";
 
 import { userAPI } from "@/api/settings";
 import { MemberSettings } from "@/types/member";
@@ -63,13 +63,13 @@ export default function SettingsSheet() {
     <Sheet open={open} onOpenChange={setOpen}>
       <SheetTrigger asChild>
         <button>
-          <Settings size={32} color="#F0F0F0" />
+          <IoMdSettings size={32} color="#F0F0F0" />
         </button>
       </SheetTrigger>
       <SheetContent className="w-[300px] bg-[#373A4D] opacity-90 flex flex-col rounded-l-sheet p-10 border-none text-white">
         <SheetHeader className="pb-4">
           <div className="flex justify-center items-center gap-2">
-            <Settings size={24} />
+            <IoMdSettings size={24} />
             <SheetTitle>
               <h2 className="text-h2 text-white flex items-center">설정</h2>
             </SheetTitle>

--- a/src/pages/answer-result/index.tsx
+++ b/src/pages/answer-result/index.tsx
@@ -45,11 +45,11 @@ export default function AnswerResult() {
   return (
     <>
       <div>
-        <div className="text-center pt-20 pb-10 mb-3">
-          <h2 className="text-h2 text-primary">사용자님의 보따리</h2>
-          <h5 className="text-h5">
+        <div className="text-center pt-20 pb-10 mb-3 text-white">
+          <h2 className="text-h2">{userInfo?.nickname}님의 보따리</h2>
+          <h2 className="text-h2">
             {answersData ? answersData.length : 0}개의 답변이 담겨 있어요!
-          </h5>
+          </h2>
         </div>
         {answersData && (
           <AnswerList

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -100,6 +100,9 @@ export default {
           },
         ],
       },
+      boxShadow: {
+        "custom-inner": "inset 2px 2px 4px rgba(0, 0, 0, 0.25)",
+      },
       keyframes: {
         "slide-up": {
           "0%": { transform: "translateY(100%)" },


### PR DESCRIPTION
## 무엇을 위한 PR인가요?

- [ ] 신규 기능 추가 :
- [ ] 버그 수정 :
- [x] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 :

## 변경사항 및 이유

- 답변 상세 디자인 업데이트 반영

![answer-list](https://github.com/user-attachments/assets/24ec55b7-d4f4-41c8-86f2-f0c5e142dbac)
![answer-detail](https://github.com/user-attachments/assets/81cff564-6d79-4f9b-bd2d-d01b11c691b2)
![answer-delete](https://github.com/user-attachments/assets/59bd81d5-546c-4cd7-8583-f6d89c233270)

## PR 특이 사항

- `react-icons` 라이브러리가 추가되었습니다.
  - lucide-react를 사용하고 있던 곳의 icon을 react-icons로 변경하였습니다.
  - 라이브러리가 달라졌음에 따라 크기 조정이 필요할 수 있습니다. 페이지 접근이 어려운 경우 체크를 못한 곳이 있어 작업간 확인 부탁드립니다.
- `alert-dialog` component custom
- 구슬 모양 element의 경우 답변 생성 쪽에서 컴포넌트 작업이 있었을 것으로 예상되어 컴포넌트 분리는 하지 않았습니다.
  - cc. @s2oy 
  - 만약에 분리가 안되어 있다면 추가 작업 후 커밋하겠습니다.

## Issue Number

- close: #

어떤 부분에 리뷰어가 집중하면 좋을까요?
