### PR TITLE
[BGRM-45+] 서비스 회원가입 약관 내용 페이지 추가

### DIFF
--- a/src/pages/answer-result/index.tsx
+++ b/src/pages/answer-result/index.tsx
@@ -34,9 +34,12 @@ export default function AnswerResult() {
   const getAnswersData = async () => {
     if (isLoading || !hasMore) return;
 
+    // COMMENT: strict mode에선 2번 호출로 인한 에러가 뜰 수 있으나, product에선 이슈사항 없음
+    // - 중복 호출로 인해 동일 데이터 map key 중복 에러
+    // - "start: 2" param 건너 뛰는 현상
     setIsLoading(true);
     try {
-      const { data } = state.question
+      const { data } = state?.question
         ? await answerAPI.listForGuest({
             sqidsId: state.question,
             query: paramRef.current,

--- a/src/pages/join-terms/index.tsx
+++ b/src/pages/join-terms/index.tsx
@@ -1,0 +1,16 @@
+import { ScrollArea } from "@/components/ui/scroll-area";
+import TermsOfService from "./terms/TermsOfService";
+
+export default function index() {
+  return (
+    <>
+      <div className="text-center pt-10 pb-5 mb-3 text-white">
+        <h2 className="text-h2">회원 가입 약관 동의</h2>
+      </div>
+
+      <ScrollArea className="h-[calc(100vh-240px)] rounded-lg">
+        <TermsOfService />
+      </ScrollArea>
+    </>
+  );
+}

--- a/src/pages/join-terms/terms/TermsOfService.tsx
+++ b/src/pages/join-terms/terms/TermsOfService.tsx
@@ -1,0 +1,162 @@
+export default function TermsOfService() {
+  return (
+    <div className="max-w-3xl mx-auto p-6 bg-[rgba(255,255,255,0.75)] shadow-md">
+      <h1 className="text-2xl text-center font-bold mb-6">
+        부꾸러미 서비스 이용약관
+      </h1>
+
+      <section className="mb-6">
+        <h2 className="text-xl font-semibold mb-3">제1조 (목적)</h2>
+        <p className="text-gray-800">
+          본 약관은 부꾸러미가 제공하는 질문 공유 및 답변 서비스(이하
+          "서비스")의 이용조건 및 절차, 부꾸러미와 회원 간의 권리, 의무 및
+          책임사항을 규정함을 목적으로 합니다.
+        </p>
+      </section>
+
+      <section className="mb-6">
+        <h2 className="text-xl font-semibold mb-3">제2조 (정의)</h2>
+        <ol className="list-decimal list-inside text-gray-800">
+          <li>
+            "회원"이란 본 약관에 동의하고 부꾸러미와 서비스 이용계약을 체결한
+            자를 말합니다.
+          </li>
+          <li>
+            "질문"이란 회원이 서비스 내에서 생성하고 공유하는 콘텐츠를 말합니다.
+          </li>
+          <li>
+            "답변"이란 회원이 다른 회원의 질문에 대해 작성한 콘텐츠를 말합니다.
+          </li>
+        </ol>
+      </section>
+
+      <section className="mb-6">
+        <h2 className="text-xl font-semibold mb-3">
+          제3조 (약관의 효력 및 변경)
+        </h2>
+        <ol className="list-decimal list-inside text-gray-800">
+          <li>
+            본 약관은 서비스 화면에 게시하거나 기타의 방법으로 회원에게
+            공지함으로써 효력이 발생합니다.
+          </li>
+          <li>
+            부꾸러미는 필요한 경우 관련 법령을 위배하지 않는 범위에서 본 약관을
+            변경할 수 있습니다. 약관이 변경될 경우 부꾸러미는 변경사항을 시행일
+            15일 전부터 공지하며, 회원에게 불리한 변경의 경우 30일 전부터
+            공지합니다.
+          </li>
+        </ol>
+      </section>
+
+      <section className="mb-6">
+        <h2 className="text-xl font-semibold mb-3">
+          제4조 (서비스의 제공 및 변경)
+        </h2>
+        <ol className="list-decimal list-inside text-gray-800">
+          <li>
+            부꾸러미는 다음과 같은 서비스를 제공합니다:
+            <ul className="list-disc list-inside ml-6">
+              <li>회원 가입 및 관리</li>
+              <li>질문 생성 및 공유</li>
+              <li>답변 작성 및 조회</li>
+            </ul>
+          </li>
+          <li>
+            부꾸러미는 서비스의 내용, 품질, 또는 기술적 사양 등의 변경이 필요한
+            경우 변경 사항을 사전에 공지합니다.
+          </li>
+        </ol>
+      </section>
+
+      <section className="mb-6">
+        <h2 className="text-xl font-semibold mb-3">제5조 (회원가입)</h2>
+        <ol className="list-decimal list-inside text-gray-800">
+          <li>
+            회원가입은 서비스의 회원가입 양식에 따라 필요한 정보를 기입하고 본
+            약관에 동의함으로써 완료됩니다.
+          </li>
+          <li>
+            부꾸러미는 다음 각 호에 해당하는 회원가입을 거절할 수 있습니다:
+            <ul className="list-disc list-inside ml-6">
+              <li>실명이 아니거나 타인의 명의를 이용한 경우</li>
+              <li>필수 정보를 허위로 기재한 경우</li>
+              <li>
+                법령 또는 본 약관을 위반하여 이용계약이 해지된 적이 있는 경우
+              </li>
+            </ul>
+          </li>
+        </ol>
+      </section>
+
+      <section className="mb-6">
+        <h2 className="text-xl font-semibold mb-3">제6조 (개인정보보호)</h2>
+        <p className="text-gray-800">
+          부꾸러미는 관련 법령이 정하는 바에 따라 회원의 개인정보를 보호하며,
+          개인정보의 보호 및 사용에 대해서는 관련 법령 및 부꾸러미의
+          개인정보처리방침에 따릅니다.
+        </p>
+      </section>
+
+      <section className="mb-6">
+        <h2 className="text-xl font-semibold mb-3">제7조 (회원의 의무)</h2>
+        <ol className="list-decimal list-inside text-gray-800">
+          <li>
+            회원은 다음 행위를 하여서는 안 됩니다:
+            <ul className="list-disc list-inside ml-6">
+              <li>타인의 정보를 도용하거나 허위정보를 등록하는 행위</li>
+              <li>부꾸러미가 제공하는 서비스에 정보를 허위로 기재하는 행위</li>
+              <li>타인의 명예를 손상시키거나 불이익을 주는 행위</li>
+              <li>
+                부꾸러미의 저작권, 제3자의 저작권 등 기타 권리를 침해하는 행위
+              </li>
+              <li>
+                공공질서 및 미풍양속에 위반되는 내용의 정보 등을 공개 또는
+                게시하는 행위
+              </li>
+            </ul>
+          </li>
+        </ol>
+      </section>
+
+      <section className="mb-6">
+        <h2 className="text-xl font-semibold mb-3">제8조 (게시물의 관리)</h2>
+        <p className="text-gray-800">
+          회원의 게시물이 관련 법령 및 본 약관에 위반되는 내용을 포함하는 경우,
+          부꾸러미는 해당 게시물을 삭제 또는 게시 중단할 수 있습니다.
+        </p>
+      </section>
+
+      <section className="mb-6">
+        <h2 className="text-xl font-semibold mb-3">
+          제9조 (서비스 이용의 제한)
+        </h2>
+        <p className="text-gray-800">
+          부꾸러미는 회원이 본 약관의 의무를 위반하거나 서비스의 정상적인 운영을
+          방해한 경우, 서비스 이용을 제한할 수 있습니다.
+        </p>
+      </section>
+
+      <section className="mb-6">
+        <h2 className="text-xl font-semibold mb-3">제10조 (책임제한)</h2>
+        <ol className="list-decimal list-inside text-gray-800">
+          <li>
+            부꾸러미는 천재지변 또는 이에 준하는 불가항력으로 인하여 서비스를
+            제공할 수 없는 경우에는 서비스 제공에 관한 책임이 면제됩니다.
+          </li>
+          <li>
+            부꾸러미는 회원의 귀책사유로 인한 서비스 이용의 장애에 대하여 책임을
+            지지 않습니다.
+          </li>
+        </ol>
+      </section>
+
+      <section className="mb-6">
+        <h2 className="text-xl font-semibold mb-3">제11조 (준거법)</h2>
+        <p className="text-gray-800">
+          본 약관의 해석 및 부꾸러미와 회원 간의 분쟁에 대하여는 대한민국의 법을
+          적용합니다.
+        </p>
+      </section>
+    </div>
+  );
+}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,24 +1,28 @@
 import { Route, Switch, Redirect, BrowserRouter } from "react-router-dom";
 
+import RootLayout from "@/components/RootLayout";
+import PrivateRoute from "@/routes/PrivateRoute";
+
 import Main from "@/pages/main";
 
 import MemberJoin from "@/pages/member-join";
 import MemberLogin from "@/pages/login-sso";
 import OAuth from "@/pages/oauth";
+import JoinTerms from "@/pages/join-terms";
 
 import QuestionCreate from "@/pages/question-create";
 import QuestionCreateDetail from "@/pages/question-create-detail";
 import QuestionCreateComplete from "@/pages/question-create-complete";
-
-import AnswerCreate from "@/pages/answer-create";
-import AnswerResult from "@/pages/answer-result";
-import SelfReflection from "@/pages/self-reflection";
 import QuestionComplete from "@/pages/question-complete";
-import PrivateRoute from "@/routes/PrivateRoute";
-import RootLayout from "@/components/RootLayout";
+
 import { Answer } from "@/pages/answer/index";
-import { DialogProvider } from "@/contexts/DialogContext";
+import AnswerCreate from "@/pages/answer-create";
 import AnswerCreateComplete from "@/pages/answer-create-complete";
+import AnswerResult from "@/pages/answer-result";
+
+import SelfReflection from "@/pages/self-reflection";
+
+import { DialogProvider } from "@/contexts/DialogContext";
 
 export default function Routing() {
   return (
@@ -32,6 +36,7 @@ export default function Routing() {
             <Route exact path="/member-login" render={() => <MemberLogin />} />
             <Route exact path="/member-join" render={() => <MemberJoin />} />
 
+            <Route exact path="/join/terms" render={() => <JoinTerms />} />
             <Route exact path="/oauth/kakao/pending" render={() => <OAuth />} />
 
             {/* quest route */}


### PR DESCRIPTION
## 무엇을 위한 PR인가요?

- [ ] 신규 기능 추가 :
- [ ] 버그 수정 :
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [x] 기타 : 서비스 약관 페이지 별도 생성

## 변경사항 및 이유

![image](https://github.com/user-attachments/assets/65d9a9dd-d21c-45fa-8170-f840671e4d91)

- 카카오 dev의 커스텀 서비스 약관 동의 추가를 위한 별도 약관 동의 내역 페이지 추가
  - 필수 약관의 경우 페이지 url이 같이 첨부되어야 하기에 퍼블리싱 진행
  - ![image](https://github.com/user-attachments/assets/e7c66739-e158-4e1f-9826-78e5e3da18c9)

## PR 특이 사항

- 약관 내용 텍스트만 따로 파일 분리할지는 고민중입니다.
- #42 에 BGRM-45 티켓이 같이 있으나, 이는 컨텐츠 면이 아닌 동의 체크 기능 면의 PR
  - 또한 이때 PR내역은 일반 회원가입에 해당되는 내용이었으므로, 현재와 별개 사항
- 약관 동의라는 면에서 같기에 티켓은 분리하지 않고 유지합니다.
- strict mode에서 중복 호출로 인해 발생하는 에러에 대해선 주석 코멘트 남겨놓았습니다.
  - 배포 이슈사항 해당 없음

## Issue Number

- close: #

어떤 부분에 리뷰어가 집중하면 좋을까요?
