### PR TITLE
Fix: 메인 페이지 컴포넌트 렌더링 이슈 해결

### DIFF
--- a/src/hooks/useLoginCheck.ts
+++ b/src/hooks/useLoginCheck.ts
@@ -1,0 +1,17 @@
+import { useMemo } from "react";
+import { useUserStore } from "@/store/userStore";
+import { tokenCookie } from "@/lib/authToken";
+
+export function useLoginCheck() {
+  const { userInfo } = useUserStore();
+
+  const isLogin = useMemo(() => {
+    return Boolean(
+      userInfo?.id &&
+        (tokenCookie.getCookie("accessToken") ||
+          tokenCookie.getCookie("refreshToken"))
+    );
+  }, [userInfo?.id]);
+
+  return { isLogin };
+}

--- a/src/pages/login-sso/index.tsx
+++ b/src/pages/login-sso/index.tsx
@@ -2,13 +2,14 @@ import { useEffect } from "react";
 import { useHistory } from "react-router-dom";
 
 import { memberAPI } from "@/api/member";
-import { useUserStore } from "@/store/userStore";
+import { useLoginCheck } from "@/hooks/useLoginCheck";
 
 import { Button } from "@/components/ui/button";
 import mascot_front_standing from "@/shared/assets/mascot/mascot-front-standing.svg";
 import { BsChatFill } from "react-icons/bs";
+
 export default function MemberLogin() {
-  const { userInfo } = useUserStore();
+  const { isLogin } = useLoginCheck();
 
   const history = useHistory();
 
@@ -19,8 +20,8 @@ export default function MemberLogin() {
   };
 
   useEffect(() => {
-    sessionStorage.clear();
-    if (userInfo) {
+    sessionStorage.removeItem("sso_type");
+    if (isLogin) {
       history.push("/main");
     }
   });

--- a/src/pages/main/index.tsx
+++ b/src/pages/main/index.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { Redirect, useHistory } from "react-router-dom";
+import { useHistory } from "react-router-dom";
 import { mainPageApi } from "@/api/main";
 import { MainPageInfo } from "@/types/main-page";
 import { useUserStore } from "@/store/userStore";
@@ -9,36 +9,37 @@ import { ShareDialog } from "@/components/share/ShareDialog";
 import WithoutAnswer from "./components/WithoutAnswer";
 import WithAnswer from "./components/WithAnswer";
 import { DialogProvider } from "@/contexts/DialogContext";
+import { useLoginCheck } from "@/hooks/useLoginCheck";
 
 export default function Main() {
   const [mainPageInfo, setMainPageInfo] = useState<MainPageInfo>();
 
+  const { isLogin } = useLoginCheck();
   const { userInfo } = useUserStore();
   const { setColorCodeList } = useSnowStore();
 
   const history = useHistory();
 
   useEffect(() => {
+    if (!isLogin) {
+      history.replace("/member-login");
+    }
     if (userInfo?.id) {
       mainPageApi.getInfo().then((res) => {
         const data = res.data.data;
         if (!data) {
           history.replace("/question-create"); // todo: 질문을 아직 만들지 않았을 때 리다이렉션 잘되는지 확인 필요
-          return null;
+          return;
         }
         setColorCodeList(data.colorCodeList);
         setMainPageInfo(data);
       });
     }
-  }, [userInfo, history, setColorCodeList]);
-
-  const hasUserId = userInfo?.id != null;
+  }, [userInfo?.id, history, isLogin]);
 
   return (
     <div className="flex flex-col h-full">
-      {!hasUserId ? (
-        <Redirect to="/member-login" />
-      ) : !mainPageInfo ? (
+      {!mainPageInfo ? (
         <div className="flex flex-col justify-between flex-grow text-white">
           <div className="flex flex-col flex-grow justify-center items-center p-5">
             <p className="mb-4 text-h5">질문을 아직 만들지 않았어요!</p>
@@ -53,20 +54,22 @@ export default function Main() {
           </footer>
         </div>
       ) : (
-        <DialogProvider>
-          <div className="flex flex-col h-full">
-            {mainPageInfo.totalCount < 1 ? (
-              <WithoutAnswer
-                userId={userInfo.id}
-                questionContent={mainPageInfo.content}
-                nickname={mainPageInfo.nickname}
-              />
-            ) : (
-              <WithAnswer userId={userInfo.id} mainPageInfo={mainPageInfo} />
-            )}
-          </div>
-          <ShareDialog userId={userInfo.id} />
-        </DialogProvider>
+        userInfo?.id && (
+          <DialogProvider>
+            <div className="flex flex-col h-full">
+              {mainPageInfo.totalCount < 1 ? (
+                <WithoutAnswer
+                  userId={userInfo.id}
+                  questionContent={mainPageInfo.content}
+                  nickname={mainPageInfo.nickname}
+                />
+              ) : (
+                <WithAnswer userId={userInfo.id} mainPageInfo={mainPageInfo} />
+              )}
+            </div>
+            <ShareDialog userId={userInfo.id} />
+          </DialogProvider>
+        )
       )}
     </div>
   );

--- a/src/pages/oauth/index.tsx
+++ b/src/pages/oauth/index.tsx
@@ -25,7 +25,7 @@ export default function OAuth() {
       if (!referrer) {
         return true;
       } else {
-        if (allowedReferers.includes(referrer)) return true;
+        return allowedReferers.includes(referrer);
       }
     }
   };

--- a/src/pages/oauth/index.tsx
+++ b/src/pages/oauth/index.tsx
@@ -48,7 +48,6 @@ export default function OAuth() {
               if (data.status === "OK") {
                 // Case0: 토큰 발행 O & 유저 정보 호출 O
                 setUserInfo(data.data);
-                sessionStorage.clear();
                 history.push("/main");
               } else {
                 // Case1: 토큰 API O & 유저 정보 API X
@@ -80,6 +79,8 @@ export default function OAuth() {
             history.push("/member-login");
           }
         }
+      } finally {
+        sessionStorage.clear(); // SSO 타입 초기
       }
     });
   }

--- a/src/routes/PrivateRoute.tsx
+++ b/src/routes/PrivateRoute.tsx
@@ -1,17 +1,16 @@
 import React from "react";
 import { Redirect, RouteProps } from "react-router-dom";
 
-import { useUserStore } from "@/store/userStore";
+import { useLoginCheck } from "@/hooks/useLoginCheck";
 
 interface PrivateRouteProps extends RouteProps {
   children: React.ReactNode;
 }
 
 export default function PrivateRoute({ children }: PrivateRouteProps) {
-  const { userInfo } = useUserStore();
-  const isAuthenticated: boolean = !!userInfo?.id;
+  const { isLogin } = useLoginCheck();
 
-  if (isAuthenticated) {
+  if (isLogin) {
     return children;
   }
 


### PR DESCRIPTION
## 무엇을 위한 PR인가요?

- [ ] 신규 기능 추가 :
- [x] 버그 수정 :
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 :

## 변경사항 및 이유

![비로그인 상태_질문 create 표시됨](https://github.com/user-attachments/assets/ef912112-a4eb-46f5-b49d-a7186487f9e1)

- 기존에 `/main`에서 로그인 체크가 user.id로만 이루어져 발생하는 UI 렌더 이슈 해결
  - 토큰이 만료되어 없는 경우에 store를 clear하는 코드가 있지만, store에 남아 있는 userId만 체크 후 화면을 렌더링 시키고 clear가 되어 발생되는 것으로 추측

## PR 특이 사항

- login checking hook 추가
  - useInfo와 token 함께 체크
- 로그인 상태를 useEffect에서 의존성 체크하도록 변경

### 추가 수정사항

- refresh token 시키는 api call이 연속적으로 발생할 경우 모두 동일 refresh token을 들고 가는데, 첫 호출에서 refresh token까지 갱신시키기 때문에 이후 요청들이 모두 만료된 이슈로 인식되어 에러 발생시킴
  - Promise 사용으로 해결

## Issue Number

- close: #

어떤 부분에 리뷰어가 집중하면 좋을까요?
