### PR TITLE
Fix: Dialog 구조 에러 이슈 해결

### DIFF
--- a/src/components/answer/AnswerCard.tsx
+++ b/src/components/answer/AnswerCard.tsx
@@ -1,4 +1,5 @@
 import { Answer } from "@/types/answer";
+import { Bead } from "@/components/bead/Bead";
 
 interface Props {
   answer: Answer;
@@ -12,10 +13,7 @@ export default function AnswerCard({ answer, onDialogOpen }: Props) {
     <div>
       <div className="flex justify-between  mb-1 text-white">
         <span className="flex gap-2 font-semibold">
-          <div
-            style={{ backgroundColor: answer.colorCode }}
-            className="w-[24px] h-[24px] rounded-full"
-          ></div>
+          <Bead color={answer.colorCode} size={25} />
           {answer.sender}님의 구슬
         </span>
         <span>{date}</span>

--- a/src/components/answer/dialog/AnswerDeleteDialog.tsx
+++ b/src/components/answer/dialog/AnswerDeleteDialog.tsx
@@ -7,6 +7,7 @@ import {
   AlertDialogDescription,
   AlertDialogFooter,
   AlertDialogHeader,
+  AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 
 type Props = {
@@ -35,13 +36,15 @@ export default function AnswerDeleteDialog({
   return (
     <AlertDialog open={isOpen} onOpenChange={onClose}>
       <AlertDialogContent>
-        <AlertDialogHeader className="text-[24px] mt-3 mb-5">
-          <h2>
-            깨진 구슬은 <strong>복구할 수 없어요!</strong>
-          </h2>
-          <h2>정말 구슬을 깨트릴까요?</h2>
+        <AlertDialogHeader className="mt-3 mb-5">
+          <AlertDialogTitle className="!text-h2">
+            <div>
+              깨진 구슬은 <strong>복구할 수 없어요!</strong>
+              <p>정말 구슬을 깨트릴까요?</p>
+            </div>
+          </AlertDialogTitle>
           <AlertDialogDescription>
-            <p>신중하게 결정하세요!</p>
+            <span>신중하게 결정하세요!</span>
           </AlertDialogDescription>
         </AlertDialogHeader>
 

--- a/src/components/answer/dialog/AnswerDetailDialog.tsx
+++ b/src/components/answer/dialog/AnswerDetailDialog.tsx
@@ -57,7 +57,7 @@ export default function AnswerDetailDialog({
           </p>
 
           <DialogFooter>
-            <Button onClick={handleDialogToggle}>닫기</Button>
+            <Button onClick={onClose}>닫기</Button>
             {!isGuestAccess && (
               <Button
                 onClick={handleDialogToggle}

--- a/src/components/answer/dialog/AnswerDetailDialog.tsx
+++ b/src/components/answer/dialog/AnswerDetailDialog.tsx
@@ -3,7 +3,12 @@ import { FaTrashAlt } from "react-icons/fa";
 
 import { Answer } from "@/types/answer";
 
-import { Dialog, DialogContent, DialogFooter } from "@/components/ui/dialog";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { Button } from "../../ui/button";
 import { Bead } from "@/components/bead/Bead";
 import AnswerDeleteDialog from "./AnswerDeleteDialog";
@@ -37,15 +42,12 @@ export default function AnswerDetailDialog({
   return (
     <>
       <Dialog open={isOpen} onOpenChange={onClose}>
-        <DialogContent className="bg-[#D6D8E1]">
+        <DialogContent className="bg-[#D6D8E1]" aria-describedby={undefined}>
           <div className="flex flex-row items-center justify-between mb-3">
-            <h2 className="flex gap-2 font-semibold">
-              <div
-                style={{ backgroundColor: data.colorCode }}
-                className="w-[24px] h-[24px] rounded-full"
-              ></div>
-              {data.sender}님의 구슬
-            </h2>
+            <DialogTitle className="flex items-center gap-2 font-semibold">
+              <Bead color={data.colorCode} size={25} />
+              <span>{data.sender}님의 구슬</span>
+            </DialogTitle>
 
             <span>{date}</span>
           </div>

--- a/src/components/answer/dialog/AnswerDetailDialog.tsx
+++ b/src/components/answer/dialog/AnswerDetailDialog.tsx
@@ -1,18 +1,19 @@
-import { FaTrashAlt } from "react-icons/fa";
-import { Dialog, DialogContent, DialogFooter } from "@/components/ui/dialog";
-
-import { Button } from "../../ui/button";
 import { useState } from "react";
-import AnswerDeleteDialog from "./AnswerDeleteDialog";
+import { FaTrashAlt } from "react-icons/fa";
 
 import { Answer } from "@/types/answer";
+
+import { Dialog, DialogContent, DialogFooter } from "@/components/ui/dialog";
+import { Button } from "../../ui/button";
+import { Bead } from "@/components/bead/Bead";
+import AnswerDeleteDialog from "./AnswerDeleteDialog";
 
 type Props = {
   isOpen: boolean;
   onClose: () => void;
   data: Answer;
   onDeleteSuccess: () => void;
-  isGuestAccess: boolean;
+  isGuestAccess?: boolean;
 };
 
 export default function AnswerDetailDialog({
@@ -20,7 +21,7 @@ export default function AnswerDetailDialog({
   onClose,
   data,
   onDeleteSuccess,
-  isGuestAccess,
+  isGuestAccess = false,
 }: Props) {
   const [isDeleteAlertOpen, setIsDeleteDialogOpen] = useState(false);
   const date = data.regDate as string;

--- a/src/components/bead/Bead.tsx
+++ b/src/components/bead/Bead.tsx
@@ -1,8 +1,8 @@
 import { CSSProperties } from "react";
 
 interface BeadProps {
-  color: CSSProperties["color"];
-  size: number;
+  color?: CSSProperties["color"];
+  size?: number;
   selected?: boolean;
   onClick?: () => void;
 }

--- a/src/components/share/ShareDialog.tsx
+++ b/src/components/share/ShareDialog.tsx
@@ -2,8 +2,8 @@ import { Button } from "@/components/ui/button";
 import {
   Dialog,
   DialogContent,
-  DialogDescription,
   DialogFooter,
+  DialogTitle,
 } from "@/components/ui/dialog";
 import CopyURLButton from "./CopyURLButton";
 import { BsChatFill } from "react-icons/bs";
@@ -31,16 +31,17 @@ export function ShareDialog({ userId }: Props) {
     <>
       {shareInfo && (
         <Dialog open={open} onOpenChange={onClose}>
-          <DialogContent>
-            <DialogDescription>
-              <h2 className="text-h2 font-medium text-gray-900">
+          <DialogContent aria-describedby={undefined}>
+            <DialogTitle className="text-center">
+              <span className="text-h2 font-medium text-gray-900">
                 친구에게
-                <span className="font-bold"> 공유</span>
+                <strong className="font-bold"> 공유</strong>
                 해
                 <br />
                 구슬을 얻어볼까요?
-              </h2>
-            </DialogDescription>
+              </span>
+            </DialogTitle>
+
             <DialogFooter>
               <div className="flex justify-center">
                 <img

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -41,7 +41,7 @@ const DialogContent = React.forwardRef<
         "bg-background",
         "p-10",
         "flex flex-col",
-        "rounded-[40px]",
+        "rounded-[40px_40px_0_0]",
         "data-[state=open]:animate-slide-up",
         "data-[state=closed]:animate-slide-down",
         className

--- a/src/pages/answer-result/index.tsx
+++ b/src/pages/answer-result/index.tsx
@@ -138,7 +138,7 @@ export default function AnswerResult() {
           onClose={handleDialogToggle}
           data={selectedItem}
           onDeleteSuccess={handleDeleteSuccess}
-          isGuestAccess={!!state.question}
+          isGuestAccess={!!state?.question}
         />
       )}
     </>


### PR DESCRIPTION
## 무엇을 위한 PR인가요?

- [ ] 신규 기능 추가 :
- [x] 버그 수정 :
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 :

## 변경사항 및 이유

![Dialog구조에러](https://github.com/user-attachments/assets/920a95c0-e8a3-4c52-9671-4939356a282a)
![Dialog구조경고](https://github.com/user-attachments/assets/05d35dec-cdd6-4c0b-8189-41cbbbd51f88)

- Dialog에서 Dialog Title은 필수 구조, Description은 권장 구조로 사용되고 있어서 각각 error와 warning을 보내고 있었습니다.
  - Title을 적용하고, 이에 따라 파생되는 DOM 구조 오류도 같이 해결
  - Dialog를 사용하는 컴포넌트들 모두 적용

## PR 특이 사항

### 구슬 컴포넌트 적용
![구슬컴포넌트 적용](https://github.com/user-attachments/assets/65341f2b-b487-45d1-bff2-081f27b02273)

- 답변 리스트 화면의 구슬도 별도로 만들던 것에서 `Bead` 컴포넌트로 적용시켰습니다.

### Dialog Layout border-radius 수정
![123](https://github.com/user-attachments/assets/8071bf1f-bbf9-4a97-8291-53e5aa905437)

- 모바일 기기마다 테두리 규격이 다르기 때문에 하단부 radius는 삭제합니다.

## Issue Number

- close: #

어떤 부분에 리뷰어가 집중하면 좋을까요?
