### PR TITLE
[QA/BGRM-17, 22, 23, 37, 44. 60] 회고 및 닉네임수정 로직 변경

### DIFF
--- a/src/components/FunnelForm/FunnelForm.tsx
+++ b/src/components/FunnelForm/FunnelForm.tsx
@@ -63,7 +63,9 @@ export function FunnelForm<T extends FieldValues>({
             )}
             {isLastStep ? (
               <Button onClick={handleSubmit} className="w-full">
-                {`완료(${currentStep}/${totalSteps})`}
+                {`${
+                  isReadOnly ? "닫기" : "완료"
+                }(${currentStep}/${totalSteps})`}
               </Button>
             ) : (
               <Button

--- a/src/features/settings/SettingsSheet.tsx
+++ b/src/features/settings/SettingsSheet.tsx
@@ -149,12 +149,17 @@ export default function SettingsSheet({
             <div className="flex gap-2">
               <Input
                 value={nickname}
-                onChange={(e) => setNickname(e.target.value)}
+                onChange={(e) => {
+                  if (e.target.value.length <= 10) {
+                    setNickname(e.target.value);
+                  }
+                }}
                 disabled={!isEditMode}
                 className={cn(
                   "bg-[#2D3241] border-none disabled:opacity-100",
                   isEditMode ? "text-white" : "text-[#868686]"
                 )}
+                maxLength={10}
               />
               <button
                 className={cn(

--- a/src/pages/answer-create-complete/index.tsx
+++ b/src/pages/answer-create-complete/index.tsx
@@ -74,8 +74,14 @@ export default function AnswerCreateComplete() {
                   의 보따리에
                 </p>
                 <p className="mb-6">
-                  <span className="font-bold">{count}번째</span> 구슬이
-                  담겼어요!
+                  {count === "n" ? (
+                    "마음이 담긴 구슬이 담겼어요!"
+                  ) : (
+                    <span>
+                      <span className="font-bold">{count}번째</span> 구슬이
+                      담겼어요!
+                    </span>
+                  )}
                 </p>
               </motion.p>
               <div className="flex justify-center">

--- a/src/pages/answer-create/index.tsx
+++ b/src/pages/answer-create/index.tsx
@@ -58,6 +58,8 @@ export default function AnswerCreate() {
     }
   };
 
+  const isNextButtonDisabled = !content.trim() || !senderName.trim();
+
   return (
     <section className="flex flex-col h-full gap-6 justify-between">
       <div className="flex flex-col my-auto gap-4">
@@ -113,6 +115,7 @@ export default function AnswerCreate() {
       <div className="flex w-full py-10">
         <Button
           className="w-full"
+          disabled={isNextButtonDisabled}
           children={
             <div className="w-full flex flex-row items-center">
               <span className="grow">다음</span>

--- a/src/pages/answer-create/index.tsx
+++ b/src/pages/answer-create/index.tsx
@@ -107,6 +107,7 @@ export default function AnswerCreate() {
           <TextFieldWrapper
             title="보내는 사람"
             value={senderName}
+            maxLength={10}
             onChange={setSenderName}
             placeholder="이름 입력"
           />

--- a/src/pages/answer/index.tsx
+++ b/src/pages/answer/index.tsx
@@ -37,6 +37,11 @@ export function Answer() {
     }
   };
 
+  const handleLogin = () => {
+    localStorage.setItem("redirectPath", `/answer-create?question=${sqidsId}`);
+    history.push("/member-login");
+  };
+
   return (
     <div className="flex flex-col h-full justify-between">
       <div className="flex flex-col my-auto">
@@ -84,9 +89,7 @@ export function Answer() {
             onBack={() => {
               setSelectedType(null);
             }}
-            onClick={() => {
-              history.push("/member-login");
-            }}
+            onClick={handleLogin}
           />
         )}
     </div>

--- a/src/pages/answer/index.tsx
+++ b/src/pages/answer/index.tsx
@@ -82,7 +82,7 @@ export function Answer() {
             isOpen={selectedType === "START"}
             onClose={() => setSelectedType(null)}
             onBack={() => {
-              setSelectedType("DESC");
+              setSelectedType(null);
             }}
             onClick={() => {
               history.push("/member-login");

--- a/src/pages/main/index.tsx
+++ b/src/pages/main/index.tsx
@@ -35,7 +35,7 @@ export default function Main() {
         setMainPageInfo(data);
       });
     }
-  }, [userInfo?.id, history, isLogin]);
+  }, [userInfo, history, isLogin]);
 
   return (
     <div className="flex flex-col h-full">

--- a/src/pages/oauth/index.tsx
+++ b/src/pages/oauth/index.tsx
@@ -52,7 +52,7 @@ export default function OAuth() {
                   localStorage.getItem("redirectPath") || "/main";
                 history.push(redirectPath);
               } else {
-                // Case1: 토큰 API O & 유저 정보 API X3
+                // Case1: 토큰 API O & 유저 정보 API X
                 throw new Error("Fail to get user information");
               }
             });

--- a/src/pages/oauth/index.tsx
+++ b/src/pages/oauth/index.tsx
@@ -48,9 +48,11 @@ export default function OAuth() {
               if (data.status === "OK") {
                 // Case0: 토큰 발행 O & 유저 정보 호출 O
                 setUserInfo(data.data);
-                history.push("/main");
+                const redirectPath =
+                  localStorage.getItem("redirectPath") || "/main";
+                history.push(redirectPath);
               } else {
-                // Case1: 토큰 API O & 유저 정보 API X
+                // Case1: 토큰 API O & 유저 정보 API X3
                 throw new Error("Fail to get user information");
               }
             });

--- a/src/pages/self-reflection/index.tsx
+++ b/src/pages/self-reflection/index.tsx
@@ -12,7 +12,6 @@ import { ConfirmDialog } from "@/pages/self-reflection/components/ConfirmDialog"
 import { selfReflectionSchema } from "@/pages/self-reflection/schemas/reflectionSchema";
 import { useToast } from "@/hooks/use-toast";
 import { selfReflection } from "@/api/self-reflection";
-import { useHistory } from "react-router-dom";
 import {
   ReflectionAnswer,
   ReflectionQuestion,
@@ -25,22 +24,22 @@ import { FunnelForm } from "@/components/FunnelForm/FunnelForm";
 const FORM_FIELDS = [
   {
     name: "regret",
-    label: "올해 가장 후회되는 일은?",
+    label: "작년 가장 후회되는 일은?",
     placeholder: "후회되는 일을 적어주세요",
     type: "textarea",
     size: "s",
   },
   {
     name: "bestThing",
-    label: "올해 가장 잘한 일은?",
+    label: "작년 가장 잘한 일은?",
     placeholder: "잘한 일을 적어주세요",
     type: "textarea",
     size: "s",
   },
   {
     name: "nextYearGoal",
-    label: "내년에는 이것만큼은 꼭 해내야지!",
-    placeholder: "내년의 목표를 적어주세요",
+    label: "올해에는 이것만큼은 꼭 해내야지!",
+    placeholder: "올해의 목표를 적어주세요",
     type: "textarea",
     size: "s",
   },
@@ -76,7 +75,6 @@ export default function SelfReflection() {
   );
   const [step, setStep] = useState(1);
 
-  const history = useHistory();
   const { userInfo } = useUserStore();
 
   const form = useForm<z.infer<typeof selfReflectionSchema>>({
@@ -141,7 +139,9 @@ export default function SelfReflection() {
         title: "제출 완료",
         description: "회고가 성공적으로 저장되었습니다.",
       });
-      history.push("/main");
+      const answersRes = await selfReflection.getSelfReflection();
+      setExistingAnswers(answersRes.data.data);
+      setStep(1);
     } catch (error) {
       toast({
         variant: "destructive",


### PR DESCRIPTION
## 무엇을 위한 PR인가요?

- [x] 신규 기능 추가 : UI/UX 개선 및 기능 동작 수정
- [ ] 버그 수정 :
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 :

## 변경사항 및 이유

이유

작업 내역
1. 닉네임 관련 수종
- 닉네임 입력 길이 10글자로 제한
- 닉네임 수정시 메인 페이지에 실시간 반영되도록 개선

2. 회고 기능 UX개선
- 텍스트 명확성 개선: '올해' -> '작년', '내년' -> '올해'로 수정
- 회고 작성 완료 후 readonly모드 구현
- 이미 작성된 회고 조회시 '완료' -> '닫기' 버튼으로 문구 변경

3.  /answer 페이지로그인 Dialog 사용성 개선
- 뒤로가기 버튼 클릭 시 모달 닫히게 수정

4. answer-creatre-complete페이지 답변 개수 비공개일경우 문구 수정
- `00님의 보따리에 마음이 담긴 구슬이 담겼어요!` 로 표시

5. answer-create페이지 다음버튼 유효성 체크 로직 추가
- content, nickname 필드 값 입력했을 경우 `다음`버튼 활성화
## PR 특이 사항

특이 사항

## Issue Number

- close: #

어떤 부분에 리뷰어가 집중하면 좋을까요?
