### PR TITLE
[QA/BGRM-40,42,46] 눈 색상 store 설정 수정 및 구슬 삭제 후 오류 해결

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -36,11 +36,11 @@ const refreshAccessToken = async () => {
 
       if (!refreshToken) {
         localStorage.removeItem("user-storage");
+        localStorage.removeItem("snow-storage");
         throw new Error("There is no refresh token");
       }
 
-      const res = await renewToken({ refreshToken });
-      const data = res.data;
+      const { data } = await renewToken({ refreshToken });
 
       if (data.status === "OK") {
         tokenCookie.setCookie("accessToken", data.data.accessToken, 0.25);
@@ -85,6 +85,7 @@ const createAxiosInstance = (withToken: boolean = false): AxiosInstance => {
           } catch {
             tokenCookie.deleteCookie("refreshToken");
             localStorage.removeItem("user-storage");
+            localStorage.removeItem("snow-storage");
           }
         }
         return config;

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -35,8 +35,6 @@ const refreshAccessToken = async () => {
       const refreshToken = tokenCookie.getCookie("refreshToken");
 
       if (!refreshToken) {
-        localStorage.removeItem("user-storage");
-        localStorage.removeItem("snow-storage");
         throw new Error("There is no refresh token");
       }
 
@@ -86,6 +84,7 @@ const createAxiosInstance = (withToken: boolean = false): AxiosInstance => {
             tokenCookie.deleteCookie("refreshToken");
             localStorage.removeItem("user-storage");
             localStorage.removeItem("snow-storage");
+            window.location.href = "/member-login";
           }
         }
         return config;

--- a/src/components/common/LogoutButton.tsx
+++ b/src/components/common/LogoutButton.tsx
@@ -2,6 +2,7 @@ import { cn } from "@/lib/utils";
 import { Button } from "../ui/button";
 
 import { useUserStore } from "@/store/userStore";
+import { useSnowStore } from "@/store/snowStore";
 import { tokenCookie } from "@/lib/authToken";
 
 type Props = {
@@ -10,9 +11,11 @@ type Props = {
 
 export default function LogoutButton({ className }: Props) {
   const { clearUserInfo } = useUserStore();
+  const { clearColorCodeList } = useSnowStore();
 
   const logout = () => {
     clearUserInfo();
+    clearColorCodeList();
     tokenCookie.deleteCookie("accessToken");
     tokenCookie.deleteCookie("refreshToken");
   };

--- a/src/hooks/useLoginCheck.ts
+++ b/src/hooks/useLoginCheck.ts
@@ -1,9 +1,13 @@
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
+
 import { useUserStore } from "@/store/userStore";
+import { useSnowStore } from "@/store/snowStore";
+
 import { tokenCookie } from "@/lib/authToken";
 
 export function useLoginCheck() {
-  const { userInfo } = useUserStore();
+  const { userInfo, clearUserInfo } = useUserStore();
+  const { clearColorCodeList } = useSnowStore();
 
   const isLogin = useMemo(() => {
     return Boolean(
@@ -12,6 +16,15 @@ export function useLoginCheck() {
           tokenCookie.getCookie("refreshToken"))
     );
   }, [userInfo?.id]);
+
+  useEffect(() => {
+    if (!isLogin) {
+      clearUserInfo();
+      clearColorCodeList();
+      tokenCookie.deleteCookie("accessToken");
+      tokenCookie.deleteCookie("refreshToken");
+    }
+  }, [isLogin]);
 
   return { isLogin };
 }

--- a/src/pages/answer-result/index.tsx
+++ b/src/pages/answer-result/index.tsx
@@ -72,14 +72,14 @@ export default function AnswerResult() {
     }
   };
 
-  // 최초 데이터 호출
+  // 최초 데이터 호출 & 삭제 후 데이터 호출
   useEffect(() => {
     if (userInfo?.id || state.question) {
-      getAnswersData();
+      if (!answersData.length) getAnswersData();
     } else {
       history.push("member-login");
     }
-  }, [userInfo?.id, state]);
+  }, [userInfo?.id, state, answersData.length]);
 
   // 무한 스크롤 핸들러
   const handleScroll = useCallback(
@@ -107,11 +107,11 @@ export default function AnswerResult() {
   };
 
   const handleDeleteSuccess = () => {
-    handleDialogToggle();
     setAnswersData([]);
-    paramRef.current = { start: 1, limit: 10 };
+    setTotalCount(0);
     setHasMore(true);
-    if (userInfo?.id) getAnswersData();
+    paramRef.current = { start: 1, limit: 10 };
+    handleDialogToggle();
   };
 
   return (

--- a/src/store/snowStore.ts
+++ b/src/store/snowStore.ts
@@ -1,4 +1,6 @@
 import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
 import { MainPageInfo } from "@/types/main-page";
 
 interface SnowStore {
@@ -7,8 +9,13 @@ interface SnowStore {
   clearColorCodeList: () => void;
 }
 
-export const useSnowStore = create<SnowStore>()((set) => ({
-  colorCodeList: null,
-  setColorCodeList: (codeList) => set({ colorCodeList: codeList }),
-  clearColorCodeList: () => set({ colorCodeList: [] }),
-}));
+export const useSnowStore = create<SnowStore>()(
+  persist(
+    (set) => ({
+      colorCodeList: null,
+      setColorCodeList: (codeList) => set({ colorCodeList: codeList }),
+      clearColorCodeList: () => set({ colorCodeList: [] }),
+    }),
+    { name: "snow-storage" }
+  )
+);


### PR DESCRIPTION
## 무엇을 위한 PR인가요?

- [ ] 신규 기능 추가 :
- [x] 버그 수정 :
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 :

## 변경사항 및 이유

- 구슬 리스트 페이지에서 새로고침 시 눈 색상 초기화 이슈
  - `snowStore`가 메인에서 세팅 된 후 넘어가기 때문에 발생
  - persist 처리 및 로그아웃에 clear 추가
- 구슬 삭제 후 리스트가 갱신 안되던 이슈
  - React 상태의 비동기 처리로 인해 발생
  - useEffect 처리

## PR 특이 사항

- 추가 수정 사항으로 `useLoginCheck` hook에 auto logout과 관련된 코드가 추가되었습니다.
  - refresh token까지 만료된 경우엔 api index의 interceptor내의 체크 로직을 통해 리다이렉트되는 것이 아니라 useLoginCheck로 로그인 여부 체크 후 `PrivateRoute.tsx`를 통해 리다이렉트 되기 때문에 store clear가 되지 않았음
  - 이 와 관련해 로그인 여부 판단 후 로그아웃 상태라면 clear 시키도록 추가

## Issue Number

- close: #

어떤 부분에 리뷰어가 집중하면 좋을까요?
