### PR TITLE
[QA/BGRM-18, 29] 구슬 생성 시 색깔 관련 로직 오류 수정

### DIFF
--- a/src/components/bead/Bead.tsx
+++ b/src/components/bead/Bead.tsx
@@ -34,8 +34,26 @@ export const Bead = ({
               offset="0%"
               style={{ stopColor: "white", stopOpacity: 0.6 }}
             />
-            <stop offset="30%" style={{ stopColor: color, stopOpacity: 0.9 }} />
-            <stop offset="100%" style={{ stopColor: color, stopOpacity: 1 }} />
+            <stop
+              offset="30%"
+              style={{
+                stopColor:
+                  color.startsWith("#") && color.length === 7
+                    ? color
+                    : `#${color}`,
+                stopOpacity: 0.9,
+              }}
+            />
+            <stop
+              offset="100%"
+              style={{
+                stopColor:
+                  color.startsWith("#") && color.length === 7
+                    ? color
+                    : `#${color}`,
+                stopOpacity: 1,
+              }}
+            />
           </radialGradient>
           <radialGradient id={highlightId} cx="35%" cy="35%">
             <stop

--- a/src/constant/color.ts
+++ b/src/constant/color.ts
@@ -1,14 +1,5 @@
-export const COLOR_CODE_LIST: string[] = [
-  "#FF6F6F",
-  "#FF9F6F",
-  "#FFEA6F",
-  "#A2FF6F",
-  "#6FFF6F",
-  "#6FFFD2",
-  "#6FFFFF",
-  "#6F9FFF",
-  "#6F6FFF",
-  "#9F6FFF",
-  "#FF6FFF",
-  "#FF6FA2",
+export const COLOR_CODE_LIST: string[][] = [
+  ["#EF4C4D", "#FF884D", "#FFC44E", "#89C94D", "#0A8403"],
+  ["#4DC3FF", "#3451E3", "#A071FF", "#832AFE", "#FF4DA5"],
+  ["#FFC088", "#BD6C41", "#FFFFFF", "#8E8E8E", "#000000"],
 ];

--- a/src/pages/answer-create/index.tsx
+++ b/src/pages/answer-create/index.tsx
@@ -14,12 +14,6 @@ import { useToast } from "@/hooks/use-toast";
 import { useQuery } from "@/hooks/useQuery";
 import { useQuestionInfo } from "@/hooks/useQuestionInfo";
 
-const colorGroups = [
-  ["EF4C4D", "FF884D", "FFC44E", "89C94D", "0A8403"],
-  ["4DC3FF", "3451E3", "A071FF", "832AFE", "FF4DA5"],
-  ["FFC088", "BD6C41", "FFFFFF", "8E8E8E", "000000"],
-];
-
 export default function AnswerCreate() {
   const { toast } = useToast();
   const history = useHistory();
@@ -31,7 +25,9 @@ export default function AnswerCreate() {
     redirectTo: "/answer",
   });
 
-  const [colorCode, setColorCode] = useState<string | undefined>(undefined);
+  const [colorCode, setColorCode] = useState<string | undefined>(
+    COLOR_CODE_LIST[0][0]
+  );
   const [content, setContent] = useState<string>("");
   const [senderName, setSenderName] = useState<string>("");
 
@@ -43,7 +39,7 @@ export default function AnswerCreate() {
         questionId: questionInfo.questionId,
         sender: senderName.trim(),
         content: content.trim(),
-        colorCode: colorCode ?? COLOR_CODE_LIST[0],
+        colorCode: colorCode ?? COLOR_CODE_LIST[0][0],
       });
       history.push(
         `/answer-create-complete?question=${sqidsId}&count=${
@@ -72,12 +68,12 @@ export default function AnswerCreate() {
           </div>
         </div>
         <div className="w-full flex flex-col items-center gap-4">
-          {colorGroups.map((group, groupIndex) => (
+          {COLOR_CODE_LIST.map((group, groupIndex) => (
             <div key={groupIndex} className="flex gap-1">
               {group.map((color) => (
                 <Bead
                   key={color}
-                  color={`#${color}`}
+                  color={color}
                   size={36}
                   selected={colorCode === color}
                   onClick={() => setColorCode(color)}


### PR DESCRIPTION
## 무엇을 위한 PR인가요?

- [ ] 신규 기능 추가 :
- [x] 버그 수정 :
- [x] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 :

## 변경사항 및 이유

### 구슬(답변)이 저장된 후 눈송이와 리스트에 색이 지정되지 않는 문제
#### 1. 의존성 배열 일관성 문제
  - 아래와 같이 색상 설정과 관련한 의존성 배열이 두개로 나뉘어져 있고, 각각 설정된 색상도 달라 일치 시킵니다.
  ![image](https://github.com/user-attachments/assets/6933dff2-b918-447f-a527-62861f156a38)
#### 2. 분리되어 있던 색상 배열의 `#`의 유무 차이
  - 의존성이 나뉘어져 있는 상태에서 기본 디폴트값에 의존하고 있던 상수 파일(`COLOR_CODE_LIST`)에는 `#`이 붙어 있어 아무 색상을 지정하지 않았을 땐 색이 저장되는데 반해, 색을 지정하는데 기여하는 `colorGroups` 배열에서는 `#`이 붙어 있지 않아 구슬 저장 후 색이 지정되지 않았습니다.
    - api param설정 간 `#`을 붙이는 방법(setColorCode(`#${color}`))과 배열 값 자체에 `#`을 붙이는 두가지 방법이 있는데, 배열값에 `#`을 붙이도록 합니다.
      - 이는 `Bead.tsx` 컴포넌트의 prop전달 간에 가공 또한 줄여 사용 일관성 유지를 위함입니다.
      - 의존 배열 자체에 `#`이 붙었을 때 사이드 이펙트가 있는 것이 아니기 때문에, 이 방법이 적은 코드 수정으로 같은 결과를 볼 수 있습니다.

### 참고 사항
#### `Bead.tsx` 수정 사항
![image](https://github.com/user-attachments/assets/beb7e5e9-f0c4-4683-9f9d-4461ebd39539)
- 이번 PR 수정 내역으로 이후 저장되는 구슬에는 색 지정 오류가 수정되어 서비스 배포에도 영향이 없지만, 테스트 간에 잘못 저장된(`#`이 없이 저장된) 값들도 개선하는 방향으로 소급 적용하는 코드도 추가하였습니다.
  - 현 PR이 머지되면 불필요할 수 있는 코드이지만, 오류 수정 후에도 현재 DB에 잘못 저장된 값들이 테스트에 이상 현상으로 비춰질 여지가 있어 테스트 편의를 위해 추가합니다.
  - 일종의 방어 로직으로 작용합니다.

## PR 특이 사항

- cc. @s2oy 

## Issue Number

- close: #

어떤 부분에 리뷰어가 집중하면 좋을까요?
