### PR TITLE
[QA/BGRM-5,27] 메인페이지 수정

### DIFF
--- a/src/pages/main/components/BundleString.tsx
+++ b/src/pages/main/components/BundleString.tsx
@@ -6,10 +6,15 @@ type Props = {
 };
 
 export default function BundleString({ questionContent, className }: Props) {
+  const questionContentLength = questionContent.length;
   return (
     <span
       className={cn(
-        "text-primary bg-white text-nowrap py-1 px-4 rounded-xl border-2 border-primary",
+        "text-primary bg-white py-1 px-4 rounded-xl border-2 border-primary",
+        {
+          "text-nowrap": questionContentLength < 25,
+          "w-[20rem]": questionContentLength >= 25,
+        },
         className
       )}
     >

--- a/src/pages/main/components/NicknameDisplay.tsx
+++ b/src/pages/main/components/NicknameDisplay.tsx
@@ -1,0 +1,11 @@
+type Props = {
+  nickname: string;
+};
+
+export default function NicknameDisplay({ nickname }: Props) {
+  return (
+    <h2 className="font-bold text-h2 mb-2 text-center text-white break-keep">
+      {nickname}님의 보따리에
+    </h2>
+  );
+}

--- a/src/pages/main/components/WithAnswer.tsx
+++ b/src/pages/main/components/WithAnswer.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import { ReflectionButton } from "./ReflectionButton";
 import ShareButton from "@/components/share/ShareButton";
 import { useHistory } from "react-router-dom";
+import NicknameDisplay from "./NicknameDisplay";
 
 type Props = {
   userId: number;
@@ -29,9 +30,7 @@ export default function WithAnswer({
     <div className="flex flex-col h-full">
       <div className="flex flex-col my-auto">
         <div className="flex flex-col items-center">
-          <h2 className="font-bold text-h2 mb-2 text-center text-white">
-            {nickname}님의 보따리에
-          </h2>
+          <NicknameDisplay nickname={nickname} />
           <span className="text-white text-h2 mb-6">
             {answerCount}개의 답변이 담겨 있어요!
           </span>

--- a/src/pages/main/components/WithoutAnswer.tsx
+++ b/src/pages/main/components/WithoutAnswer.tsx
@@ -33,7 +33,7 @@ export default function WithoutAnswer({
             기다려 볼까요?
           </span>
           <span className="text-white font-nanum-dahaengce mb-2">
-            다시 한번 공유해볼까요?
+            다시 한 번 공유해 볼까요?
           </span>
         </div>
       </div>

--- a/src/pages/main/components/WithoutAnswer.tsx
+++ b/src/pages/main/components/WithoutAnswer.tsx
@@ -2,6 +2,7 @@ import BUNDLE_WITHOUT_ANSWER from "@/assets/image/main/bundle_without_answer.png
 import ShareButton from "@/components/share/ShareButton";
 import { ReflectionButton } from "@/pages/main/components/ReflectionButton";
 import Bundle from "./Bundle";
+import NicknameDisplay from "./NicknameDisplay";
 
 type Props = {
   userId: number;
@@ -18,9 +19,7 @@ export default function WithoutAnswer({
     <div className="flex flex-col h-full">
       <div className="flex flex-col my-auto">
         <div className="flex flex-col items-center">
-          <h2 className="font-bold text-h2 mb-2 text-center text-white">
-            {nickname}님의 보따리에
-          </h2>
+          <NicknameDisplay nickname={nickname} />
           <span className="text-h2 text-white mb-6">아직은 답변이 없어요.</span>
           <Bundle
             bundleImageSrc={BUNDLE_WITHOUT_ANSWER}

--- a/src/pages/main/index.tsx
+++ b/src/pages/main/index.tsx
@@ -4,12 +4,12 @@ import { mainPageApi } from "@/api/main";
 import { MainPageInfo } from "@/types/main-page";
 import { useUserStore } from "@/store/userStore";
 import { useSnowStore } from "@/store/snowStore";
-import { Button } from "@/components/ui/button";
 import { ShareDialog } from "@/components/share/ShareDialog";
 import WithoutAnswer from "./components/WithoutAnswer";
 import WithAnswer from "./components/WithAnswer";
 import { DialogProvider } from "@/contexts/DialogContext";
 import { useLoginCheck } from "@/hooks/useLoginCheck";
+import { Skeleton } from "@/components/ui/skeleton";
 
 export default function Main() {
   const [mainPageInfo, setMainPageInfo] = useState<MainPageInfo>();
@@ -35,23 +35,18 @@ export default function Main() {
         setMainPageInfo(data);
       });
     }
-  }, [userInfo?.id, history, isLogin]);
+  }, [userInfo?.id, history, isLogin, setColorCodeList]);
 
   return (
     <div className="flex flex-col h-full">
       {!mainPageInfo ? (
-        <div className="flex flex-col justify-between flex-grow text-white">
-          <div className="flex flex-col flex-grow justify-center items-center p-5">
-            <p className="mb-4 text-h5">질문을 아직 만들지 않았어요!</p>
+        <div className="flex flex-col h-full gap-4 justify-center">
+          <Skeleton className="w-full h-10 bg-gray-400" />
+          <Skeleton className="w-full h-10 bg-gray-400" />
+          <Skeleton className="w-full h-80 bg-gray-400" />
+          <div className="flex justify-center items-center py-10">
+            <Skeleton className="w-full h-10 bg-gray-400" />
           </div>
-          <footer className="flex justify-center items-center py-10">
-            <Button
-              className="w-full"
-              onClick={() => history.replace("/question-create")}
-            >
-              질문 만들러가기
-            </Button>
-          </footer>
         </div>
       ) : (
         userInfo?.id && (


### PR DESCRIPTION
## 무엇을 위한 PR인가요?

- [x] 신규 기능 추가 :
- [ ] 버그 수정 :
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 :

## 변경사항 및 이유
- main 페이지에서 데이터가 안받아와졌을 때 화면 스켈레톤으로 변경

https://github.com/user-attachments/assets/7e223638-a1af-45f9-8a6b-097339e5d465



- 글자 수에 따라 보따리끈 적절하게 보이도록 스타일 수정
   - 최대 글자 수가 50자라 이에 맞게 25자 넘어가면 두줄로 바뀌도록 수정했습니다!
- 닉네임 길면 이상하게 잘려보이는 것 수정


<img width="338" alt="스크린샷 2025-01-06 오후 4 50 28" src="https://github.com/user-attachments/assets/fdf4d753-7f9f-4d97-ad92-9d3ee236e8bb" />


- 일부 맞춤법 수정


## PR 특이 사항

bgrm-5의 하위 태스크인 bgrm-30(공유하기 팝업 관련)은 일단 킵해두겠습니다

## Issue Number

- close: #

어떤 부분에 리뷰어가 집중하면 좋을까요?
