### PR TITLE
[QA/BGRM-21(56), 57, 66] 게스트가 다른 유저의 보따리를 열어볼 수 있는 루트 추가

### DIFF
--- a/src/api/answer/index.ts
+++ b/src/api/answer/index.ts
@@ -40,7 +40,7 @@ export const answerAPI = {
   listForGuest: async (
     param: T.GetAnswerListForGuestParam
   ): Promise<AxiosResponse<T.GetAnswerListResponse>> => {
-    const res = await apiWithToken.get(`guest/answer/list/${param.sqidsId}`, {
+    const res = await api.get(`guest/answer/list/${param.sqidsId}`, {
       params: param.query,
     });
 

--- a/src/hooks/useQuestionInfo.ts
+++ b/src/hooks/useQuestionInfo.ts
@@ -52,7 +52,7 @@ export function useQuestionInfo({
       if (questionInfo.isAuthRequired && !userInfo?.id) {
         history.push(`/answer?question=${sqidsId}`);
       }
-    } catch (err) {
+    } catch {
       toast({
         description: "질문 정보를 불러오는데 실패했습니다.",
         variant: "destructive",

--- a/src/pages/answer-create-complete/index.tsx
+++ b/src/pages/answer-create-complete/index.tsx
@@ -42,23 +42,34 @@ export default function AnswerCreateComplete() {
     };
   }, []);
 
-  const handleClick = () => {
-    history.push("/question-create");
+  const handleGoToFriendPouch = () => {
+    history.push(`/answer-result?question=${sqidsId}`);
+  };
+  const handleGoToMakePouch = () => {
+    history.push("/main");
+    /**
+     * 비로그인 유저면 로그인 유도됨
+     * 로그인 유저일 경우
+     * - 보따리가 만들어져 있으면 일반 메인
+     * - 보따리가 안만들어져 있으면 보따리 만들기로 유도
+     */
   };
 
   return (
     <section className="flex flex-col h-full">
       <AnimatePresence>
         {isGifVisible && (
-          <motion.img
-            key="gif"
-            src={WORKING_MASCOT_GIF}
-            alt="GIF"
-            initial={{ opacity: 1 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            transition={{ duration: 0.5 }}
-          />
+          <div className="mt-[50%]">
+            <motion.img
+              key="gif"
+              src={WORKING_MASCOT_GIF}
+              alt="GIF"
+              initial={{ opacity: 1 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: 0.5 }}
+            />
+          </div>
         )}
         {isPngVisible && (
           <>
@@ -78,7 +89,7 @@ export default function AnswerCreateComplete() {
                   담겼어요!
                 </p>
               </motion.p>
-              <div className="flex justify-center">
+              <div className="flex flex-col items-center gap-5">
                 <motion.img
                   key="png"
                   src={POUCH_WITH_ANSWER_IMAGE}
@@ -88,6 +99,15 @@ export default function AnswerCreateComplete() {
                   transition={{ duration: 0.5 }}
                   className="w-1/2"
                 />
+
+                {questionInfo?.isPublicVisible && (
+                  <Button
+                    onClick={handleGoToFriendPouch}
+                    className="bg-[#414B79]"
+                  >
+                    친구 보따리 열어보기
+                  </Button>
+                )}
               </div>
             </div>
             <div className="py-10">
@@ -97,7 +117,7 @@ export default function AnswerCreateComplete() {
                 transition={{ duration: 0.5 }}
                 className="mt-6"
               >
-                <Button className="w-full" onClick={handleClick}>
+                <Button onClick={handleGoToMakePouch} className="w-full">
                   나도 보따리 만들러가기
                 </Button>
               </motion.div>

--- a/src/pages/answer-create/index.tsx
+++ b/src/pages/answer-create/index.tsx
@@ -58,13 +58,11 @@ export default function AnswerCreate() {
     <section className="flex flex-col h-full gap-6 justify-between">
       <div className="flex flex-col my-auto gap-4">
         <div className="flex flex-col items-center ">
-          <p className="text-center text-white text-xl">
-            {questionInfo.nickname}님이
-            <br />
-            답변을 기다려요!
+          <p className="text-center text-white text-lg">
+            {questionInfo.nickname}님이 답변을 기다려요!
           </p>
-          <div className="flex items-center justify-center w-full h-10 text-center rounded-md text-xs">
-            <span className="text-[#CFD2E4]">난 올해 어떤 사람이였어?</span>
+          <div className="flex items-center justify-center w-full h-10 text-center rounded-md text-2xl font-bold">
+            <span className="text-[#CFD2E4]">{questionInfo.content}</span>
           </div>
         </div>
         <div className="w-full flex flex-col items-center gap-4">
@@ -111,7 +109,7 @@ export default function AnswerCreate() {
           className="w-full"
           children={
             <div className="w-full flex flex-row items-center">
-              <span className="grow">다음</span>
+              <span className="grow">완료</span>
               <IoChevronForward className="shrink-0" />
             </div>
           }

--- a/src/pages/answer-result/index.tsx
+++ b/src/pages/answer-result/index.tsx
@@ -17,7 +17,7 @@ export default function AnswerResult() {
   const { userInfo } = useUserStore();
 
   const query = useQuery();
-  const sqidsId = query.get("question") as string;
+  const sqidsId = query.get("question");
   const [nickname, setNickname] = useState<string>("");
 
   const [isDetailDialogOpen, setIsDetailDialogOpen] = useState(false);

--- a/src/pages/answer-result/index.tsx
+++ b/src/pages/answer-result/index.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useRef, useCallback } from "react";
-import { useLocation, useHistory } from "react-router-dom";
+import { useHistory } from "react-router-dom";
 
 import AnswerList from "@/components/answer/AnswerList";
 import AnswerDetailDialog from "@/components/answer/dialog/AnswerDetailDialog";
@@ -10,11 +10,15 @@ import { Answer } from "@/types/answer";
 import { GetAnswerListParam } from "@/api/answer/type";
 
 import { useUserStore } from "@/store/userStore";
+import { useQuery } from "@/hooks/useQuery";
 
 export default function AnswerResult() {
   const history = useHistory();
   const { userInfo } = useUserStore();
-  const { state } = useLocation<{ question: string }>();
+
+  const query = useQuery();
+  const sqidsId = query.get("question") as string;
+  const [nickname, setNickname] = useState<string>("");
 
   const [isDetailDialogOpen, setIsDetailDialogOpen] = useState(false);
   const [selectedItem, setSelectedItem] = useState<Answer | null>(null);
@@ -39,13 +43,14 @@ export default function AnswerResult() {
     // - "start: 2" param 건너 뛰는 현상
     setIsLoading(true);
     try {
-      const { data } = state?.question
+      const { data } = sqidsId
         ? await answerAPI.listForGuest({
-            sqidsId: state.question,
+            sqidsId,
             query: paramRef.current,
           })
         : await answerAPI.list(paramRef.current);
 
+      if (sqidsId) setNickname(data.data.nickname);
       if (data.status === "OK" && data.data.list) {
         // totalCount는 최초에만 설정
         if (!totalCount) {
@@ -74,12 +79,12 @@ export default function AnswerResult() {
 
   // 최초 데이터 호출 & 삭제 후 데이터 호출
   useEffect(() => {
-    if (userInfo?.id || state.question) {
+    if (userInfo?.id || sqidsId) {
       if (!answersData.length) getAnswersData();
     } else {
       history.push("member-login");
     }
-  }, [userInfo?.id, state, answersData.length]);
+  }, [userInfo?.id, sqidsId, answersData.length]);
 
   // 무한 스크롤 핸들러
   const handleScroll = useCallback(
@@ -117,7 +122,7 @@ export default function AnswerResult() {
   return (
     <>
       <div className="text-center pt-20 pb-10 mb-3 text-white">
-        <h2 className="text-h2">{userInfo?.nickname}님의 보따리</h2>
+        <h2 className="text-h2">{userInfo?.nickname || nickname}님의 보따리</h2>
         <h2 className="text-h2">{totalCount}개의 답변이 담겨 있어요!</h2>
       </div>
 
@@ -138,7 +143,7 @@ export default function AnswerResult() {
           onClose={handleDialogToggle}
           data={selectedItem}
           onDeleteSuccess={handleDeleteSuccess}
-          isGuestAccess={!!state?.question}
+          isGuestAccess={!!sqidsId}
         />
       )}
     </>

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -117,11 +117,7 @@ export default function Routing() {
             <Route
               exact
               path="/answer-result"
-              render={() => (
-                <PrivateRoute>
-                  <AnswerResult />
-                </PrivateRoute>
-              )}
+              render={() => <AnswerResult />}
             />
 
             <Redirect to="/" />

--- a/src/widgets/header/Header.tsx
+++ b/src/widgets/header/Header.tsx
@@ -24,10 +24,15 @@ export default function Header() {
     const isCreatedCompletePage =
       (location.pathname === "/question-complete" && isLogin) ||
       location.pathname === "/answer-create-complete";
+    const isGuestAccess =
+      location.pathname === "/answer-result" &&
+      location.search.includes("question");
     const isQuestionRoute = location.pathname.startsWith("/question");
 
     setIsShowMainLogo(isMainPage);
-    setIsShowHomeButton(isCreatedCompletePage || isAnswerIntro);
+    setIsShowHomeButton(
+      isCreatedCompletePage || isAnswerIntro || isGuestAccess
+    );
 
     setIsShowSettingButton(isMainPage || isQuestionRoute);
     setIsShowOnlyLogout(isQuestionRoute);


### PR DESCRIPTION
## 무엇을 위한 PR인가요?

- [x] 신규 기능 추가 :
- [ ] 버그 수정 :
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 :

## 변경사항 및 이유

### 다른 유저 보따리 열어보기 기능
- 게스트 접근 루트 추가
  - 설정 옵션에 따라 버튼은 show/hide 됩니다.
  - ![친구 보따리 보기 버튼](https://github.com/user-attachments/assets/3b844e31-1d70-412a-9499-e6d7fccffbe2)
- 게스트 구슬 리스트 화면 접근 기능 연결
  - 이 경우엔 뒤로가기 버튼이 아닌 홈버튼이 보입니다.
  - ![게스트_답변리스트](https://github.com/user-attachments/assets/4edb662e-c122-464c-ab2b-b726e193c4de)

### 나도 보따리 만들러 가기 기능
- 현재 로그인 여부와 보따리 생성 유무를 따지지 않고 무조건 `question-create`로 이동시키는 이슈
  - `/main`으로 이동하도록 수정, 아래와 같은 흐름으로 보따리 생성 flow 구성 가능
    - 비로그인 시 로그인 유도
    - 로그인 후
      - 보따리가 있을 경우 자연스럽게 메인 화면 노출(중복생성 방지)
      - 없을 경우 보따리 만들기 버튼을 통해 생성 가이드

### 기타
- gif 위치가 가운데에 오게 조정했습니다.
  - ![gif위치조정](https://github.com/user-attachments/assets/2ee2554b-55a7-463b-b7ad-294ae8924921)

## PR 특이 사항

- 없음

## Issue Number

- close: #

어떤 부분에 리뷰어가 집중하면 좋을까요?
