### PR TITLE
[BGRM-45] 회원가입 서비스 약관 관련 기능 구현

### DIFF
--- a/src/api/member/index.ts
+++ b/src/api/member/index.ts
@@ -38,4 +38,11 @@ export const memberAPI = {
 
     return res;
   },
+  termsAgree: async (
+    param: T.TermsAgreeParam
+  ): Promise<AxiosResponse<T.TermsAgreeResponse>> => {
+    const res = await apiWithToken.put("/member/terms-agreement", param);
+
+    return res;
+  },
 };

--- a/src/api/member/type.ts
+++ b/src/api/member/type.ts
@@ -22,6 +22,7 @@ export type MemberSearchResponse = BaseResponse<{
   isPublicVisible: 0 | 1;
   isCountVisible: 0 | 1;
   isAuthRequired: 0 | 1;
+  isTermsAgreed: 0 | 1;
 }>;
 
 export type GetTokenParam = { code: string };
@@ -35,3 +36,8 @@ export type RefreshTokenResponse = BaseResponse<{
   accessToken: string;
   refreshToken: string;
 }>;
+
+export type TermsAgreeParam = {
+  isTermsAgreed: 0 | 1;
+};
+export type TermsAgreeResponse = BaseResponse<null>;

--- a/src/components/agree-terms/RejectDialog.tsx
+++ b/src/components/agree-terms/RejectDialog.tsx
@@ -1,0 +1,52 @@
+import { useHistory } from "react-router-dom";
+import { useLoginCheck } from "@/hooks/useLoginCheck";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+
+type Props = {
+  isOpen: boolean;
+  onClose: () => void;
+};
+
+export default function RejectDialog({ isOpen, onClose }: Props) {
+  const history = useHistory();
+  const { userLogClear } = useLoginCheck();
+
+  const handleTermsReject = async () => {
+    userLogClear();
+    history.push("/member-login");
+  };
+
+  return (
+    <AlertDialog open={isOpen} onOpenChange={onClose}>
+      <AlertDialogContent>
+        <AlertDialogHeader className="mt-3 mb-5">
+          <AlertDialogTitle className="!text-h2">
+            <div>
+              <p>약관 동의를 거부하시겠습니까?</p>
+            </div>
+          </AlertDialogTitle>
+          <AlertDialogDescription>
+            <span>거부하실 경우 서비스 이용에 제약이 있습니까?</span>
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+
+        <AlertDialogFooter>
+          <AlertDialogAction onClick={handleTermsReject}>
+            거부
+          </AlertDialogAction>
+          <AlertDialogCancel>취소</AlertDialogCancel>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/components/agree-terms/RejectDialog.tsx
+++ b/src/components/agree-terms/RejectDialog.tsx
@@ -31,9 +31,7 @@ export default function RejectDialog({ isOpen, onClose }: Props) {
       <AlertDialogContent>
         <AlertDialogHeader className="mt-3 mb-5">
           <AlertDialogTitle className="!text-h2">
-            <div>
-              <p>약관 동의를 거부하시겠습니까?</p>
-            </div>
+            <p>약관 동의를 거부하시겠습니까?</p>
           </AlertDialogTitle>
           <AlertDialogDescription>
             <span>거부하실 경우 서비스 이용에 제약이 있습니까?</span>

--- a/src/components/answer/dialog/AnswerDeleteDialog.tsx
+++ b/src/components/answer/dialog/AnswerDeleteDialog.tsx
@@ -38,10 +38,10 @@ export default function AnswerDeleteDialog({
       <AlertDialogContent>
         <AlertDialogHeader className="mt-3 mb-5">
           <AlertDialogTitle className="!text-h2">
-            <div>
+            <p>
               깨진 구슬은 <strong>복구할 수 없어요!</strong>
-              <p>정말 구슬을 깨트릴까요?</p>
-            </div>
+            </p>
+            <p>정말 구슬을 깨트릴까요?</p>
           </AlertDialogTitle>
           <AlertDialogDescription>
             <span>신중하게 결정하세요!</span>

--- a/src/components/common/LogoutButton.tsx
+++ b/src/components/common/LogoutButton.tsx
@@ -1,23 +1,17 @@
 import { cn } from "@/lib/utils";
 import { Button } from "../ui/button";
 
-import { useUserStore } from "@/store/userStore";
-import { useSnowStore } from "@/store/snowStore";
-import { tokenCookie } from "@/lib/authToken";
+import { useLoginCheck } from "@/hooks/useLoginCheck";
 
 type Props = {
   className?: string;
 };
 
 export default function LogoutButton({ className }: Props) {
-  const { clearUserInfo } = useUserStore();
-  const { clearColorCodeList } = useSnowStore();
+  const { userLogClear } = useLoginCheck();
 
   const logout = () => {
-    clearUserInfo();
-    clearColorCodeList();
-    tokenCookie.deleteCookie("accessToken");
-    tokenCookie.deleteCookie("refreshToken");
+    userLogClear();
   };
 
   return (

--- a/src/hooks/useLoginCheck.ts
+++ b/src/hooks/useLoginCheck.ts
@@ -17,14 +17,18 @@ export function useLoginCheck() {
     );
   }, [userInfo?.id]);
 
+  const userLogClear = () => {
+    clearUserInfo();
+    clearColorCodeList();
+    tokenCookie.deleteCookie("accessToken");
+    tokenCookie.deleteCookie("refreshToken");
+  };
+
   useEffect(() => {
     if (!isLogin) {
-      clearUserInfo();
-      clearColorCodeList();
-      tokenCookie.deleteCookie("accessToken");
-      tokenCookie.deleteCookie("refreshToken");
+      userLogClear();
     }
   }, [isLogin]);
 
-  return { isLogin };
+  return { isLogin, userLogClear };
 }

--- a/src/pages/join-terms/index.tsx
+++ b/src/pages/join-terms/index.tsx
@@ -1,16 +1,124 @@
-import { ScrollArea } from "@/components/ui/scroll-area";
-import TermsOfService from "./terms/TermsOfService";
+import { useState } from "react";
+import { Redirect, useHistory } from "react-router-dom";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
 
-export default function index() {
+import { memberAPI } from "@/api/member";
+import { TermsAgreeParam } from "@/api/member/type";
+
+import { useUserStore } from "@/store/userStore";
+import { termsSchema, TermsAgreementType } from "./schema/termsSchema";
+
+import { ScrollArea } from "@/components/ui/scroll-area";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Button } from "@/components/ui/button";
+import TermsOfService from "./terms/TermsOfService";
+import RejectDialog from "@/components/agree-terms/RejectDialog";
+
+export default function JoinTerms() {
+  const history = useHistory();
+
+  const { userInfo, updateUserInfo } = useUserStore();
+  const [isOpen, setIsOpen] = useState(false);
+
+  const form = useForm<TermsAgreementType>({
+    resolver: zodResolver(termsSchema),
+    defaultValues: {
+      agreeTerms: false,
+    },
+  });
+
+  const onSubmit = (values: TermsAgreementType) => {
+    const param: TermsAgreeParam = {
+      isTermsAgreed: values.agreeTerms ? 1 : 0,
+    };
+
+    try {
+      if (param.isTermsAgreed) {
+        memberAPI.termsAgree(param).then((res) => {
+          const data = res.data;
+
+          if (data.status === "OK") {
+            updateUserInfo({ isTermsAgreed: 1 });
+          }
+        });
+      }
+    } finally {
+      const redirectPath = localStorage.getItem("redirectPath") || "/main";
+      history.push(redirectPath);
+      localStorage.removeItem("redirectPath");
+    }
+  };
+
+  const toggleDialog = () => {
+    setIsOpen(!isOpen);
+  };
+
+  if (userInfo?.isTermsAgreed) {
+    return <Redirect to="/main" />;
+  }
+
   return (
     <>
-      <div className="text-center pt-10 pb-5 mb-3 text-white">
-        <h2 className="text-h2">회원 가입 약관 동의</h2>
+      <div className="flex flex-col items-center">
+        <div>
+          <div className="text-center pt-4 pb-5 text-white">
+            <h2 className="text-h2">회원 가입 약관 동의</h2>
+          </div>
+          <ScrollArea className="h-[calc(100vh-340px)] rounded-lg">
+            <TermsOfService />
+          </ScrollArea>
+        </div>
+
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="mt-8">
+            <FormField
+              control={form.control}
+              name="agreeTerms"
+              render={({ field }) => (
+                <>
+                  <FormItem className="flex items-center gap-2 space-y-0">
+                    <FormControl>
+                      <Checkbox
+                        checked={field.value}
+                        onCheckedChange={field.onChange}
+                      />
+                    </FormControl>
+                    <FormLabel className="leading-none text-lg text-white">
+                      약관을 모두 확인하였습니다.
+                    </FormLabel>
+                  </FormItem>
+                  <FormMessage className="text-center" />
+                </>
+              )}
+            />
+
+            <div className="flex justify-center gap-4 mt-5">
+              <Button type="submit" size="lg">
+                동의
+              </Button>
+              <Button
+                type="button"
+                onClick={toggleDialog}
+                variant="secondary"
+                size="lg"
+              >
+                거부
+              </Button>
+            </div>
+          </form>
+        </Form>
       </div>
 
-      <ScrollArea className="h-[calc(100vh-240px)] rounded-lg">
-        <TermsOfService />
-      </ScrollArea>
+      <RejectDialog isOpen={isOpen} onClose={toggleDialog} />
     </>
   );
 }

--- a/src/pages/join-terms/schema/termsSchema.ts
+++ b/src/pages/join-terms/schema/termsSchema.ts
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const termsSchema = z.object({
+  agreeTerms: z.boolean().refine((value) => value === true, {
+    message: "서비스 약관을 확인해주세요.",
+  }),
+});
+export type TermsAgreementType = z.infer<typeof termsSchema>;

--- a/src/pages/oauth/index.tsx
+++ b/src/pages/oauth/index.tsx
@@ -48,9 +48,15 @@ export default function OAuth() {
               if (data.status === "OK") {
                 // Case0: 토큰 발행 O & 유저 정보 호출 O
                 setUserInfo(data.data);
-                const redirectPath =
-                  localStorage.getItem("redirectPath") || "/main";
-                history.push(redirectPath);
+                // 약관 동의 여부 확인
+                if (data.data.isTermsAgreed) {
+                  const redirectPath =
+                    localStorage.getItem("redirectPath") || "/main";
+                  history.push(redirectPath);
+                  localStorage.removeItem("redirectPath");
+                } else {
+                  history.push("/join/terms");
+                }
               } else {
                 // Case1: 토큰 API O & 유저 정보 API X
                 throw new Error("Fail to get user information");

--- a/src/routes/PrivateRoute.tsx
+++ b/src/routes/PrivateRoute.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Redirect, RouteProps } from "react-router-dom";
 
 import { useLoginCheck } from "@/hooks/useLoginCheck";
+import { useUserStore } from "@/store/userStore";
 
 interface PrivateRouteProps extends RouteProps {
   children: React.ReactNode;
@@ -9,10 +10,15 @@ interface PrivateRouteProps extends RouteProps {
 
 export default function PrivateRoute({ children }: PrivateRouteProps) {
   const { isLogin } = useLoginCheck();
+  const { userInfo } = useUserStore();
 
-  if (isLogin) {
-    return children;
+  if (!isLogin) {
+    return <Redirect to="/member-login" />;
+  } else {
+    if (!userInfo?.isTermsAgreed) {
+      return <Redirect to="/join/terms" />;
+    } else {
+      return children;
+    }
   }
-
-  return <Redirect to="/member-login" />;
 }

--- a/src/store/userStore.ts
+++ b/src/store/userStore.ts
@@ -6,6 +6,7 @@ import { MemberSearchResponse } from "@/api/member/type";
 interface UserStore {
   userInfo: MemberSearchResponse["data"] | null;
   setUserInfo: (info: MemberSearchResponse["data"]) => void;
+  updateUserInfo: (updateInfo: Partial<MemberSearchResponse["data"]>) => void;
   clearUserInfo: () => void;
 }
 
@@ -15,6 +16,12 @@ export const useUserStore = create<UserStore>()(
       userInfo: null,
       setUserInfo: (info: MemberSearchResponse["data"]) =>
         set({ userInfo: info }),
+      updateUserInfo: (updatedInfo: Partial<MemberSearchResponse["data"]>) =>
+        set((state) => ({
+          userInfo: state.userInfo
+            ? { ...state.userInfo, ...updatedInfo }
+            : null,
+        })),
       clearUserInfo: () => set({ userInfo: null }),
     }),
     {

--- a/src/widgets/header/Header.tsx
+++ b/src/widgets/header/Header.tsx
@@ -47,7 +47,8 @@ export default function Header() {
       ) : isShowHomeButton ? (
         <HomeButton />
       ) : (
-        location.pathname !== "/member-login" && <BackButton />
+        location.pathname !== "/member-login" &&
+        location.pathname !== "/join/terms" && <BackButton />
       )}
       {isShowSettingButton && (
         <SettingsSheet showOnlyLogout={isShowOnlyLogout} />


### PR DESCRIPTION
## 무엇을 위한 PR인가요?

- [x] 신규 기능 추가 :
- [ ] 버그 수정 :
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 :

## 변경사항 및 이유

- 새로 구현된 회원가입 약관 동의 api 세팅 및 연결
- pending 사이트에서 약관 동의 회원인지 판단 후 메인 혹은 약관 동의 페이지로 이동하도록 수정
  - 약관 미동의 회원일 경우 약관 동의 페이지에서 동의하면 메인으로 이동
  - 약관 동의 거부 시엔 유저정보 clear 후에 다시 로그인 페이지로 이동
- `PrivateRoute`에 로그인 여부 + 약관 동의 여부에 따라 리다이렉트가 이뤄지도록 조건을 추가했습니다.

![약관동의 페이지](https://github.com/user-attachments/assets/15980387-bcaa-4eb9-ad48-ba580fa95656)
![약관동의 페이지_미체크](https://github.com/user-attachments/assets/4b489e72-e9de-4aef-9bff-acd0dfdc786b)
![약관거부_dialog](https://github.com/user-attachments/assets/93bc004a-84b0-4491-a08f-0e2a7fbcbd7e)

## PR 특이 사항

- 로그아웃 시 실행되는 유저정보/눈송이 색상정보/토큰 정보 삭제 기능이 여러 곳에 사용될 기능이라 `useLoginCheck` 훅에 하나의 함수로 묶어두었습니다.
- `로그인유저만 허용한 질문`에 대해 공유 링크로 접근 시 로그인 후 다시 답변 남기기 쪽으로 이동하게 되어 있었는데,
  비동의 회원일 경우엔 약관동의 화면으로 이동 후, 동의를 하게 되면 답변 남기기 쪽으로 이동하도록 하였습니다.
  - 이미 동의한 회원: 로그인 후 공유링크로 재이동
  - 약관동의 하지 않은 회원: 로그인 -> 약관 동의 후 공유링크 재이동
- `redirectPath`가 활용된 이후 제거되고 있지 않아 제거되도록 하였습니다.

## Issue Number

- close: #

어떤 부분에 리뷰어가 집중하면 좋을까요?
