### PR TITLE
[QA/BGRM-72, 80, 85, 86] 받은 구슬 리스트 UI 오류 수정 및 개선

### DIFF
--- a/src/components/answer/AnswerCard.tsx
+++ b/src/components/answer/AnswerCard.tsx
@@ -21,7 +21,7 @@ export default function AnswerCard({ answer, onDialogOpen }: Props) {
 
       <div
         onClick={onDialogOpen}
-        className="rounded-md border-2 min-h-20 p-3 bg-[#F3F3F3] font-nanum-dahaengce text-xl"
+        className="rounded-md border-2 min-h-20 p-3 bg-[#F3F3F3] font-nanum-dahaengce text-xl whitespace-pre-wrap"
       >
         <p>{answer.content}</p>
       </div>

--- a/src/components/answer/AnswerCard.tsx
+++ b/src/components/answer/AnswerCard.tsx
@@ -23,7 +23,7 @@ export default function AnswerCard({ answer, onDialogOpen }: Props) {
         onClick={onDialogOpen}
         className="rounded-md border-2 min-h-20 p-3 bg-[#F3F3F3] font-nanum-dahaengce text-xl whitespace-pre-wrap"
       >
-        <p>{answer.content}</p>
+        <p className="line-clamp-2 overflow-hidden">{answer.content}</p>
       </div>
     </div>
   );

--- a/src/components/answer/dialog/AnswerDetailDialog.tsx
+++ b/src/components/answer/dialog/AnswerDetailDialog.tsx
@@ -52,7 +52,7 @@ export default function AnswerDetailDialog({
             <span>{date}</span>
           </div>
 
-          <p className="bg-[#F3F3F3] shadow-custom-inner rounded-xl py-2 px-4 min-h-[200px] mb-10 font-nanum-dahaengce text-xl">
+          <p className="bg-[#F3F3F3] shadow-custom-inner rounded-xl py-2 px-4 min-h-[200px] mb-10 font-nanum-dahaengce text-xl whitespace-pre-wrap">
             {data.content}
           </p>
 

--- a/src/pages/answer-result/index.tsx
+++ b/src/pages/answer-result/index.tsx
@@ -122,7 +122,9 @@ export default function AnswerResult() {
   return (
     <>
       <div className="text-center pt-20 pb-10 mb-3 text-white">
-        <h2 className="text-h2">{userInfo?.nickname || nickname}님의 보따리</h2>
+        <h2 className="text-h2">
+          {sqidsId ? nickname : userInfo?.nickname}님의 보따리
+        </h2>
         <h2 className="text-h2">{totalCount}개의 답변이 담겨 있어요!</h2>
       </div>
 

--- a/src/pages/answer-result/index.tsx
+++ b/src/pages/answer-result/index.tsx
@@ -125,7 +125,13 @@ export default function AnswerResult() {
         <h2 className="text-h2">
           {sqidsId ? nickname : userInfo?.nickname}님의 보따리
         </h2>
-        <h2 className="text-h2">{totalCount}개의 답변이 담겨 있어요!</h2>
+        <h2 className="text-h2">
+          {totalCount !== -1 ? (
+            <span>{totalCount}개의 답변이 담겨 있어요!</span>
+          ) : (
+            <span>마음이 담긴 구슬이 들어있어요!</span>
+          )}
+        </h2>
       </div>
 
       <div


### PR DESCRIPTION
## 무엇을 위한 PR인가요?

- [x] 신규 기능 추가 : 말줄임 효과 추가
- [x] 버그 수정 : 게스트 입장 시 닉네임 및 카운트 표시 오류 수정, 내용 줄바꿈 처리
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 :

## 변경사항 및 이유

- 게스트로 다른 유저 페이지 입장 시 로그인 되어 있으면 본인 닉네임이 나오던 오류 수정
- 게스트로 다른 유저 페이지 입장 시 구슬 개수가 비공개면 -1로 표시되던 오류 수정
- 내용 줄바꿈 처리 적용
- 리스트 카드 내용이 2줄을 넘어갈 경우 말줄임이 되도록 적용

![갯수비공개일경우_게스트](https://github.com/user-attachments/assets/a0e65144-7555-4acd-ac52-14ccbc356bec)
![2줄 말줄임](https://github.com/user-attachments/assets/cc39fc91-0e46-401c-8faf-12a004483729)

## PR 특이 사항

- 없음

## Issue Number

- close: #

어떤 부분에 리뷰어가 집중하면 좋을까요?
