### PR TITLE
[QA/BGRM-78, 71, 81] 메인페이지 수정

### DIFF
--- a/src/pages/answer-result/index.tsx
+++ b/src/pages/answer-result/index.tsx
@@ -123,7 +123,7 @@ export default function AnswerResult() {
     <>
       <div className="text-center pt-20 pb-10 mb-3 text-white">
         <h2 className="text-h2">{userInfo?.nickname || nickname}님의 보따리</h2>
-        <h2 className="text-h2">{totalCount}개의 답변이 담겨 있어요!</h2>
+        <h2 className="text-h2">{totalCount}개의 구슬이 담겨 있어요!</h2>
       </div>
 
       <div

--- a/src/pages/main/components/WithAnswer.tsx
+++ b/src/pages/main/components/WithAnswer.tsx
@@ -32,7 +32,7 @@ export default function WithAnswer({
         <div className="flex flex-col items-center">
           <NicknameDisplay nickname={nickname} />
           <span className="text-white text-h2 mb-6">
-            {answerCount}개의 답변이 담겨 있어요!
+            {answerCount}개의 구슬이 담겨 있어요!
           </span>
           <Bundle
             bundleImageSrc={BUNDLE_WITH_ANSWER_IMAGE}
@@ -40,7 +40,7 @@ export default function WithAnswer({
             questionContent={questionContent}
           />
           <h3 className="font-bold mb-2 w-full text-left text-white">
-            담긴 쪽지 미리보기
+            담긴 구슬 미리보기
           </h3>
           <Link
             to={"/answer-result"}
@@ -53,7 +53,7 @@ export default function WithAnswer({
 
       <footer className="w-full pb-10">
         <p className="font-nanum-dahaengce mb-2 text-center text-white text-xl">
-          누구의 쪽지일까요? 지금 열어보세요!
+          누구의 구슬일까요? 지금 열어보세요!
         </p>
         <Button
           className="mb-2 w-full"

--- a/src/pages/main/components/WithAnswer.tsx
+++ b/src/pages/main/components/WithAnswer.tsx
@@ -4,7 +4,7 @@ import { MainPageInfo } from "@/types/main-page";
 import { Button } from "@/components/ui/button";
 import { ReflectionButton } from "./ReflectionButton";
 import ShareButton from "@/components/share/ShareButton";
-import { useHistory } from "react-router-dom";
+import { Link, useHistory } from "react-router-dom";
 import NicknameDisplay from "./NicknameDisplay";
 
 type Props = {
@@ -42,9 +42,12 @@ export default function WithAnswer({
           <h3 className="font-bold mb-2 w-full text-left text-white">
             담긴 쪽지 미리보기
           </h3>
-          <p className="bg-[#F3F3F3] w-full px-4 py-3 rounded-md mb-4 h-24 overflow-y-auto font-nanum-dahaengce">
+          <Link
+            to={"/answer-result"}
+            className="block bg-[#F3F3F3] w-full px-4 py-3 rounded-md mb-4 h-24 overflow-y-auto font-nanum-dahaengce"
+          >
             {previewMessage}
-          </p>
+          </Link>
         </div>
       </div>
 

--- a/src/pages/main/components/WithoutAnswer.tsx
+++ b/src/pages/main/components/WithoutAnswer.tsx
@@ -20,14 +20,14 @@ export default function WithoutAnswer({
       <div className="flex flex-col my-auto">
         <div className="flex flex-col items-center">
           <NicknameDisplay nickname={nickname} />
-          <span className="text-h2 text-white mb-6">아직은 답변이 없어요.</span>
+          <span className="text-h2 text-white mb-6">아직은 구슬이 없어요.</span>
           <Bundle
             bundleImageSrc={BUNDLE_WITHOUT_ANSWER}
             className="w-40 mb-4"
             questionContent={questionContent}
           />
           <span className="font-nanum-dahaengce text-white">
-            조금만 더 답변을
+            조금만 더 구슬을
           </span>
           <span className="font-nanum-dahaengce text-white mb-10">
             기다려 볼까요?

--- a/src/pages/main/index.tsx
+++ b/src/pages/main/index.tsx
@@ -28,15 +28,14 @@ export default function Main() {
       mainPageApi.getInfo().then((res) => {
         const data = res.data.data;
         if (!data) {
-          history.replace("/question-create"); // todo: 질문을 아직 만들지 않았을 때 리다이렉션 잘되는지 확인 필요
+          history.replace("/question-create");
           return;
         }
         setColorCodeList(data.colorCodeList);
         setMainPageInfo(data);
       });
     }
-  }, [userInfo, history, isLogin]);
-
+  }, [userInfo, history, isLogin, setColorCodeList]);
 
   return (
     <div className="flex flex-col h-full">


### PR DESCRIPTION
## 무엇을 위한 PR인가요?

- [x] 신규 기능 추가 :
- [ ] 버그 수정 :
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 :

## 변경사항 및 이유

- 메시지 미리보기 클릭하면 답변 리스트로 이동하도록 변경
- 답변, 쪽지를 구슬로 통일

## PR 특이 사항

BGRM-71에 해당되는 이슈는 카카오톡으로 공유시 보이는 앱로고, 타이틀을 수정하는 것으로, 카카오 디벨로퍼스에서 설정 몇개만 수정하면 되기 때문에 커밋에는 포함되지 않았습니다.


<img width="466" alt="스크린샷 2025-01-08 오후 6 25 39" src="https://github.com/user-attachments/assets/0b4491da-6353-4a45-8624-e195350b64be" />


## Issue Number

- close: #

어떤 부분에 리뷰어가 집중하면 좋을까요?
