### PR TITLE
[QA/BGRM-69, 82, 83, 84] 로그인 화면 문구 수정 및 답변 페이지 접근 유저 flow 개선

### DIFF
--- a/src/features/settings/SettingsSheet.tsx
+++ b/src/features/settings/SettingsSheet.tsx
@@ -190,7 +190,7 @@ export default function SettingsSheet({
             </div>
             <div className="flex items-center justify-between">
               <Label htmlFor="marble-count" className="text-body font-semibold">
-                구슬(답변) 개수 공개
+                구슬 개수 공개
               </Label>
               <Switch
                 id="marble-count"
@@ -216,7 +216,7 @@ export default function SettingsSheet({
                 htmlFor="pouch-visible"
                 className="text-body font-semibold"
               >
-                내 보따리 공개
+                받은 구슬 공개
               </Label>
               <Switch
                 id="pouch-visible"

--- a/src/pages/answer-result/index.tsx
+++ b/src/pages/answer-result/index.tsx
@@ -121,25 +121,21 @@ export default function AnswerResult() {
 
   return (
     <>
-      <div className="text-center pt-20 pb-10 mb-3 text-white">
-
-        
-
+      <div className="text-center pt-8 pb-10 text-white">
         <h2 className="text-h2">
-          {sqidsId ? nickname : userInfo?.nickname}님의 보따리
+          {sqidsId ? nickname : userInfo?.nickname}님의 보따리에
         </h2>
         <h2 className="text-h2">
           {totalCount !== -1 ? (
-            <span>{totalCount}개의 답변이 담겨 있어요!</span>
+            <span>{totalCount}개의 구슬이 담겨 있어요!</span>
           ) : (
             <span>마음이 담긴 구슬이 들어있어요!</span>
           )}
         </h2>
-
       </div>
 
       <div
-        className="h-[calc(100vh-350px)] overflow-auto"
+        className="h-[calc(100vh-300px)] overflow-auto"
         onScroll={handleScroll}
       >
         <AnswerList listData={answersData} onDialogOpen={handleDialogToggle} />

--- a/src/pages/answer/index.tsx
+++ b/src/pages/answer/index.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@/components/ui/button";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { AnswerDescButtonSheet } from "./answer-desc-botton-sheet/AnswerDescBottonSheet";
 import { AnswerStartButton } from "./answer-start-botton-sheet/AnswerStartBottonSheet";
 import { useUserStore } from "@/store/userStore";
@@ -38,9 +38,14 @@ export function Answer() {
   };
 
   const handleLogin = () => {
-    localStorage.setItem("redirectPath", `/answer-create?question=${sqidsId}`);
+    localStorage.setItem("redirectPath", `/answer?question=${sqidsId}`);
     history.push("/member-login");
   };
+
+  // 로그인 후 접근했을 때 삭제
+  useEffect(() => {
+    if (userInfo?.id) localStorage.removeItem("redirectPath");
+  }, [userInfo?.id]);
 
   return (
     <div className="flex flex-col h-full justify-between">

--- a/src/pages/join-terms/index.tsx
+++ b/src/pages/join-terms/index.tsx
@@ -54,7 +54,6 @@ export default function JoinTerms() {
     } finally {
       const redirectPath = localStorage.getItem("redirectPath") || "/main";
       history.push(redirectPath);
-      localStorage.removeItem("redirectPath");
     }
   };
 

--- a/src/pages/login-sso/index.tsx
+++ b/src/pages/login-sso/index.tsx
@@ -31,6 +31,9 @@ export default function MemberLogin() {
       <div className="flex flex-col h-full justify-between">
         <div className="flex flex-col my-auto">
           <div className="text-center mb-3 text-white">
+            <p className="font-nanum-dahaengce text-3xl mb-12">
+              당신은 어떤 사람인가요?
+            </p>
             <h2 className="text-h2">로그인</h2>
             <h3 className="mt-2 font-extralight">login</h3>
           </div>
@@ -41,8 +44,8 @@ export default function MemberLogin() {
             </div>
 
             <div className="text-center my-10 text-white font-nanum-dahaengce text-[23px]">
-              <p>올해의 나에 대해</p>
-              <p>되돌아보러 갈까요?</p>
+              <p>여러분을 생각하는 사람들의 마음을</p>
+              <p>부꾸가 전달해줄게요!</p>
             </div>
           </div>
         </div>

--- a/src/pages/login-sso/index.tsx
+++ b/src/pages/login-sso/index.tsx
@@ -43,8 +43,8 @@ export default function MemberLogin() {
               <img src={mascot_front_standing} alt="부꾸 캐릭터" />
             </div>
 
-            <div className="text-center my-10 text-white font-nanum-dahaengce text-[23px]">
-              <p>여러분을 생각하는 사람들의 마음을</p>
+            <div className="text-center mt-6 mb-10 text-white font-nanum-dahaengce text-[23px]">
+              <p>전해 듣고 싶은 속마음이 있지 않나요?</p>
               <p>부꾸가 전달해줄게요!</p>
             </div>
           </div>

--- a/src/pages/main/components/WithAnswer.tsx
+++ b/src/pages/main/components/WithAnswer.tsx
@@ -44,7 +44,7 @@ export default function WithAnswer({
           </h3>
           <Link
             to={"/answer-result"}
-            className="block bg-[#F3F3F3] w-full px-4 py-3 rounded-md mb-4 h-24 overflow-y-auto font-nanum-dahaengce"
+            className="block bg-[#F3F3F3] w-full px-4 py-3 rounded-md mb-4 h-24 overflow-y-auto font-nanum-dahaengce whitespace-pre-wrap"
           >
             {previewMessage}
           </Link>

--- a/src/pages/main/components/WithAnswer.tsx
+++ b/src/pages/main/components/WithAnswer.tsx
@@ -48,13 +48,13 @@ export default function WithAnswer({
           >
             {previewMessage}
           </Link>
+          <p className="font-nanum-dahaengce mb-2 text-center text-white text-xl">
+            누구의 구슬일까요? 지금 열어보세요!
+          </p>
         </div>
       </div>
 
       <footer className="w-full pb-10">
-        <p className="font-nanum-dahaengce mb-2 text-center text-white text-xl">
-          누구의 구슬일까요? 지금 열어보세요!
-        </p>
         <Button
           className="mb-2 w-full"
           children="열어보기"

--- a/src/pages/oauth/index.tsx
+++ b/src/pages/oauth/index.tsx
@@ -1,6 +1,6 @@
 import { useLocation, useHistory, Redirect } from "react-router-dom";
-import { memberAPI } from "@/api/member";
 
+import { memberAPI } from "@/api/member";
 import { tokenCookie } from "@/lib/authToken";
 
 import { Skeleton } from "@/components/ui/skeleton";
@@ -53,7 +53,6 @@ export default function OAuth() {
                   const redirectPath =
                     localStorage.getItem("redirectPath") || "/main";
                   history.push(redirectPath);
-                  localStorage.removeItem("redirectPath");
                 } else {
                   history.push("/join/terms");
                 }
@@ -88,7 +87,7 @@ export default function OAuth() {
           }
         }
       } finally {
-        sessionStorage.clear(); // SSO 타입 초기
+        sessionStorage.removeItem("sso_type"); // SSO 타입 초기
       }
     });
   }

--- a/src/pages/question-create-detail/index.tsx
+++ b/src/pages/question-create-detail/index.tsx
@@ -75,7 +75,7 @@ export default function QuestionCreateDetail() {
               htmlFor="show-answer-counts"
               className="font-bold text-sm text-white"
             >
-              구슬(답변) 개수 공개
+              구슬 개수 공개
             </Label>
             <Switch
               id="show-answer-counts"
@@ -101,7 +101,7 @@ export default function QuestionCreateDetail() {
               htmlFor="is-public-visible"
               className="font-bold text-sm text-white"
             >
-              내 보따리 공개
+              받은 구슬 공개
             </Label>
             <Switch
               id="is-public-visible"


### PR DESCRIPTION
## 무엇을 위한 PR인가요?

- [ ] 신규 기능 추가 :
- [ ] 버그 수정 :
- [x] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 :

## 변경사항 및 이유

### 로그인 페이지 문구 수정
- 서비스 기획에 맞춰 문구 수정되었습니다.
![2](https://github.com/user-attachments/assets/6eb5ae05-322a-4ac5-b707-a9a2bb6d0f28)

### 답변 페이지 접근 유저 flow 개선
- 기존 플로우: 비로그인 유저가 로그인 유저만 답변 허용하는 공유 링크 접근 시 로그인 후 다시 `answer-create?question=`페이지로 리다이렉트
  - 이 과정에서 history의 이전 페이지가 'oauth' 쪽으로 잡혀 뒤로가기 버튼이 UX적으로 먹통이 되는 이슈 발생
- 개선 플로우: 로그인 이후 공유 링크로 리다이렉트 될 때 `answer?qustion?=`쪽으로 되도록 수정
  - `/answer-create`가 아닌 `/answer`로 이동시킴으로써 적은 리소스로 헤더 뒤로가기 이슈 해결 가능하고, 유저 경험에 큰 피로가 아니라고 판단됨

## PR 특이 사항

- 위에서 언급한 유저 플로우와 관련하여 `redirectPath`가 계속 localStorage에 남아있던 이슈를 #83 에서 해결하였는데 로직 개선
  - 비동기적으로 처리될 경우 redirectPath가 먼저 지워지는 문제 가능성 해결
- 기타 css 수정
  - 메인 화면의 preview도 줄바꿈이 되도록 적용
  - 답변 리스트 페이지의 헤더 영역 padding 축소
  - 일부 문구 위치 조정 및 수정

![aa](https://github.com/user-attachments/assets/0f7c947a-6652-43c7-8983-4b9834c602ac)
![image](https://github.com/user-attachments/assets/29ec72e0-261c-4b15-926e-4a767b8c5d74)

## Issue Number

- close: #

어떤 부분에 리뷰어가 집중하면 좋을까요?
